### PR TITLE
Piece logic 

### DIFF
--- a/frontend/src/components/Square.jsx
+++ b/frontend/src/components/Square.jsx
@@ -1,15 +1,24 @@
 import { Graphics } from 'pixi.js';
 
-export default function createSquare({ x, y, size, color, highlighted = false, highlightColor = 0xffff00, onClick = null }) {
-  const square = new Graphics()
-    .rect(0, 0, size, size)
-    .fill({ color });
+export default function createSquare({
+  x, y, size,
+  color,
+  highlighted = false,
+  highlightColor = 0xffff00,
+  onClick = null
+}) {
+  const square = new Graphics();
 
+  // Base square fill
+  square.rect(0, 0, size, size).fill({ color });
+
+  // Inner highlight stroke (fully inside the square)
   if (highlighted) {
-    square.setStrokeStyle({ width: 4, color: highlightColor });
-    square.rect(0, 0, size, size);
-    square.stroke();
-  } 
+    const inset = 4; // pixels inset from each edge
+    square
+      .rect(inset, inset, size - 2 * inset, size - 2 * inset)
+      .stroke({ color: highlightColor, width: 6 });
+  }
 
   square.x = x;
   square.y = y;
@@ -18,7 +27,6 @@ export default function createSquare({ x, y, size, color, highlighted = false, h
   if (typeof onClick === 'function') {
     square.addEventListener('pointertap', () => {
       onClick({ x, y });
-
     });
   }
 

--- a/frontend/src/pixi/drawBoard.js
+++ b/frontend/src/pixi/drawBoard.js
@@ -1,62 +1,135 @@
 import createSquare from '~/components/Square';
-import { selectedSquare, setSelectedSquare, pieces } from '~/state/gameState';
+import {
+  selectedSquare,
+  setSelectedSquare,
+  pieces,
+  setPieces,
+  highlights,
+  setHighlights
+} from '~/state/gameState';
 import { Assets, Sprite } from 'pixi.js';
+import { highlightValidMovesForPiece } from '~/pixi/highlight';
 
 const TILE_SIZE = 80;
-const loadedSprites = {};
+const loadedTextures = {};
 
-export async function drawBoard(app) {
-  app.stage.removeChildren();
-  app.stage.sortableChildren = true;
+// Utility: Checks if the given square is selected
+function isSquareSelected(rowIndex, columnIndex) {
+  const currentSelection = selectedSquare();
+  return currentSelection &&
+    currentSelection.row === rowIndex &&
+    currentSelection.col === columnIndex;
+}
 
-  for (let row = 0; row < 8; row++) {
-    for (let col = 0; col < 8; col++) {            
-      let isDark = (row + col) % 2 === 1;
-      const fillColor = isDark ? 0x7f7f7f : 0xffffff;
+// Utility: Gets highlight metadata for a square
+function getHighlightData(rowIndex, columnIndex) {
+  return highlights().find(highlight =>
+    highlight.row === rowIndex && highlight.col === columnIndex
+  );
+}
 
-      const isSelected =
-        selectedSquare() &&
-        selectedSquare().row === row &&
-        selectedSquare().col === col;
+// Handles square click logic: move, select, or deselect
+async function handleSquareClick(rowIndex, columnIndex, pixiApplication) {
+  const clickedPiece = pieces().find(
+    piece => piece.row === rowIndex && piece.col === columnIndex
+  );
 
-      const square = createSquare({
-        x: col * TILE_SIZE,
-        y: row * TILE_SIZE,
-        size: TILE_SIZE,
-        color: fillColor,
-        highlighted: isSelected,
-        highlightColor: 0xffff00,
-        onClick: () => {
-          console.log('Selected:', row, col);
-          setSelectedSquare({ row, col });
-          drawBoard(app);
+  const isTargetSquareHighlighted = highlights().some(
+    highlight => highlight.row === rowIndex && highlight.col === columnIndex
+  );
+
+  if (isTargetSquareHighlighted && selectedSquare()) {
+    const updatedPieces = pieces()
+      .filter(
+        piece => !(piece.row === rowIndex && piece.col === columnIndex) // remove captured
+      )
+      .map(piece => {
+        if (
+          piece.row === selectedSquare().row &&
+          piece.col === selectedSquare().col
+        ) {
+          return { ...piece, row: rowIndex, col: columnIndex }; // move selected
         }
+        return piece;
       });
 
-      // Bump selected (highlighted) square to the top
-      square.zIndex = isSelected ? 1 : 0;
-      app.stage.addChild(square);
+    setPieces(updatedPieces);
+    setSelectedSquare(null);
+    setHighlights([]);
+  } else if (clickedPiece && !isSquareSelected(rowIndex, columnIndex)) {
+    setSelectedSquare({ row: rowIndex, col: columnIndex });
+
+    const newHighlights = [];
+    highlightValidMovesForPiece(
+      clickedPiece,
+      (highlightRow, highlightCol, color) => {
+        newHighlights.push({
+          row: highlightRow,
+          col: highlightCol,
+          color
+        });
+      },
+      pieces()
+    );
+
+    setHighlights(newHighlights);
+  } else {
+    setSelectedSquare(null);
+    setHighlights([]);
+  }
+
+  await drawBoard(pixiApplication);
+}
+
+// Renders board squares and piece sprites to the PixiJS stage
+export async function drawBoard(pixiApplication) {
+  pixiApplication.stage.removeChildren();
+  pixiApplication.stage.sortableChildren = true;
+
+  // Draw each square
+  for (let rowIndex = 0; rowIndex < 8; rowIndex++) {
+    for (let columnIndex = 0; columnIndex < 8; columnIndex++) {
+      const isDarkSquare = (rowIndex + columnIndex) % 2 === 1;
+      const backgroundColor = isDarkSquare ? 0x005500 : 0x55FF55;
+
+      const selected = isSquareSelected(rowIndex, columnIndex);
+      const highlightData = getHighlightData(rowIndex, columnIndex);
+      const isHighlighted = !!highlightData;
+      const highlightBorderColor = highlightData?.color ?? 0xffff00;
+
+      const squareGraphic = createSquare({
+        x: columnIndex * TILE_SIZE,
+        y: rowIndex * TILE_SIZE,
+        size: TILE_SIZE,
+        color: backgroundColor,
+        highlighted: selected || isHighlighted,
+        highlightColor: highlightBorderColor,
+        onClick: () => handleSquareClick(rowIndex, columnIndex, pixiApplication)
+      });
+
+      pixiApplication.stage.addChild(squareGraphic);
     }
   }
 
-  // Draw Pieces
+  // Draw each piece
   for (const piece of pieces()) {
-    const textureId = `/sprites/${piece.color}${piece.type}.png`;
+    const texturePath = `/sprites/${piece.color}${piece.type}.png`;
 
-    if (!loadedSprites[textureId]) {
-      const texture = await Assets.load(textureId);
+    if (!loadedTextures[texturePath]) {
+      const texture = await Assets.load(texturePath);
       texture.source.scaleMode = 'nearest';
       texture.source.style.update();
-      loadedSprites[textureId] = texture;
+      loadedTextures[texturePath] = texture;
     }
 
-    const sprite = new Sprite(loadedSprites[textureId]);    
-    const scale = TILE_SIZE / sprite.texture.width;
-    sprite.scale.set(scale);
+    const pieceSprite = new Sprite(loadedTextures[texturePath]);
+    const scaleFactor = TILE_SIZE / pieceSprite.texture.width;
+    pieceSprite.scale.set(scaleFactor);
 
-    sprite.x = piece.col * TILE_SIZE;
-    sprite.y = piece.row * TILE_SIZE;
-    sprite.zIndex = 2;
-    app.stage.addChild(sprite);
+    pieceSprite.x = piece.col * TILE_SIZE;
+    pieceSprite.y = piece.row * TILE_SIZE;
+    pieceSprite.zIndex = 2;
+
+    pixiApplication.stage.addChild(pieceSprite);
   }
 }

--- a/frontend/src/pixi/highlight.js
+++ b/frontend/src/pixi/highlight.js
@@ -1,0 +1,12 @@
+import * as Pawn from '~/pixi/pieces/Pawn';
+
+const pieceLogicMap = {
+  Pawn,
+};
+
+export function highlightValidMovesForPiece(piece, addHighlight, allPieces) {
+  const logic = pieceLogicMap[piece.type];
+  if (logic?.highlightMoves) {
+    logic.highlightMoves(piece, addHighlight, allPieces);
+  }
+}

--- a/frontend/src/pixi/pieces/Pawn.js
+++ b/frontend/src/pixi/pieces/Pawn.js
@@ -1,0 +1,33 @@
+import { getPieceAt, isOpponentPiece } from '~/pixi/utils';
+
+/**
+ * Highlight all valid moves for a Pawn.
+ * @param {Object} piece - The Pawn piece.
+ * @param {Function} addHighlight - Callback to add a highlighted square.
+ * @param {Array} allPieces - Current game state of pieces.
+ */
+export function highlightMoves(piece, addHighlight, allPieces) {
+  const { row, col, color } = piece;
+  const direction = color === 'White' ? 1 : -1;
+  const startRow = color === 'White' ? 1 : 6;
+
+  // One step forward
+  const forward1 = { row: row + direction, col };
+  if (!getPieceAt(forward1, allPieces)) {
+    addHighlight(forward1.row, forward1.col, 0xffff00);
+
+    // Two steps forward if at starting row
+    const forward2 = { row: row + 2 * direction, col };
+    if (row === startRow && !getPieceAt(forward2, allPieces)) {
+      addHighlight(forward2.row, forward2.col, 0xffff00);
+    }
+  }
+
+  // Diagonal captures
+  for (const dc of [-1, 1]) {
+    const diag = { row: row + direction, col: col + dc };
+    if (isOpponentPiece(diag, color, allPieces)) {
+      addHighlight(diag.row, diag.col, 0xff0000);
+    }
+  }
+}

--- a/frontend/src/pixi/utils.js
+++ b/frontend/src/pixi/utils.js
@@ -1,0 +1,22 @@
+/**
+ * Returns the piece at the given board position (row, col) or null.
+ * @param {{ row: number, col: number }} pos 
+ * @param {Array} allPieces 
+ * @returns {Object|null}
+ */
+export function getPieceAt(pos, allPieces) {
+    return allPieces.find(p => p.row === pos.row && p.col === pos.col) || null;
+  }
+  
+  /**
+   * Returns true if a piece at the given position exists and is an opponent.
+   * @param {{ row: number, col: number }} pos 
+   * @param {string} color - 'White' or 'Black'
+   * @param {Array} allPieces 
+   * @returns {boolean}
+   */
+  export function isOpponentPiece(pos, color, allPieces) {
+    const piece = getPieceAt(pos, allPieces);
+    return piece && piece.color !== color;
+  }
+  

--- a/frontend/src/state/gameState.js
+++ b/frontend/src/state/gameState.js
@@ -1,6 +1,8 @@
 import { createSignal } from 'solid-js';
 
 export const [selectedSquare, setSelectedSquare] = createSignal(null);
+export const [highlights, setHighlights] = createSignal([]);
+
 
 // Define a piece
 export const [pieces, setPieces] = createSignal([
@@ -23,7 +25,7 @@ export const [pieces, setPieces] = createSignal([
       type: "Pawn",
       color: "White",
       row: 1,
-      col: 0,
+      col: 1,
     },
     {
       id: 4,


### PR DESCRIPTION
This pull request includes significant changes to the chess game logic, focusing on improving the highlighting and selection of valid moves for pieces, particularly pawns. The changes include enhancements to the `createSquare` function, the `drawBoard` function, and the introduction of new utilities for highlighting valid moves.

### Enhancements to highlighting and selection logic:

* [`frontend/src/components/Square.jsx`](diffhunk://#diff-7299b6353bde6431d4b5156950515b97e3f71e0cef251649fca10b14392c0d41L3-R20): Refactored the `createSquare` function to include better handling of highlighted squares with an inner stroke.

* [`frontend/src/pixi/drawBoard.js`](diffhunk://#diff-838c3a16680e43deb76764e433581046342953ddf90e6e5821af1bc7de8ebd85L2-R133): Added utility functions `isSquareSelected` and `getHighlightData`, and refactored the `drawBoard` function to handle square clicks, highlighting valid moves, and updating the board state.

### New utilities for move highlighting:

* [`frontend/src/pixi/highlight.js`](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR1-R12): Introduced `highlightValidMovesForPiece` function to map piece types to their respective move highlighting logic.

* [`frontend/src/pixi/pieces/Pawn.js`](diffhunk://#diff-a10ed9797f8bd7de094f302378e969d0f972234c4b5b946b0696cdf9fb742d3fR1-R33): Added `highlightMoves` function to highlight all valid moves for a pawn, including forward moves and diagonal captures.

* [`frontend/src/pixi/utils.js`](diffhunk://#diff-d097d1eb08b92569add0e2580088b8ab2f526c5273922357527e144a356b0774R1-R22): Added utility functions `getPieceAt` and `isOpponentPiece` to assist in determining valid moves and opponent pieces.

### State management updates:

* [`frontend/src/state/gameState.js`](diffhunk://#diff-3a25ba3f5bd42c16ca7bf6a926d221b3df739b255353223fbfa6a40ba5668593R4-R5): Added state signals for `highlights` to manage highlighted squares and updated the initial piece positions. [[1]](diffhunk://#diff-3a25ba3f5bd42c16ca7bf6a926d221b3df739b255353223fbfa6a40ba5668593R4-R5) [[2]](diffhunk://#diff-3a25ba3f5bd42c16ca7bf6a926d221b3df739b255353223fbfa6a40ba5668593L26-R28)