### PR TITLE
Add Necropawn 

### DIFF
--- a/frontend/src/pixi/highlight.js
+++ b/frontend/src/pixi/highlight.js
@@ -5,6 +5,8 @@ import * as Knight from '~/pixi/pieces/basic/Knight';
 import * as Bishop from '~/pixi/pieces/basic/Bishop';
 import * as King from '~/pixi/pieces/basic/King';
 import * as Necromancer from '~/pixi/pieces/necro/Necromancer';
+import * as NecroPawn from '~/pixi/pieces/necro/NecroPawn';
+
 
 /**
  * Mapping of piece types to their associated highlight logic modules.
@@ -18,6 +20,7 @@ const pieceLogicMap = {
   Bishop,
   King,
   Necromancer,
+  NecroPawn,
 };
 
 /**

--- a/frontend/src/pixi/pieces/necro/NecroPawn.js
+++ b/frontend/src/pixi/pieces/necro/NecroPawn.js
@@ -1,12 +1,27 @@
-/*
-Summary:
-The NecroPawn is a corrupted pawn that serves the Necromancer race. It can march forward like any 
-ordinary pawn, but beneath its humble shell lies a terrifying ability — the power to self-destruct 
-in a burst of necrotic energy, obliterating everything around it, including allies.
+// Description:
+// This file defines the **NecroPawn**, a corrupted variant of the standard Pawn in the Battle Chess game.
+//
+// Overview:
+// - The NecroPawn is a Level 2 unit belonging to the **Necromancer Race**.
+// - It inherits standard Pawn movement: forward marching and diagonal captures.
+// - Its true power lies in its devastating **Sacrifice** ability.
+//
+// Special Ability – Sacrifice:
+// - The player can activate Sacrifice by **clicking the NecroPawn twice**:
+//   1. First click: Highlights normal moves and the unit itself (in blue).
+//   2. Second click: Highlights all adjacent tiles (AoE) in red.
+//   3. Third click: Detonates the NecroPawn, destroying itself and all surrounding pieces — both ally and enemy.
+// - To cancel Sacrifice mode, the player may simply click a different square.
+//
+// Behavior Notes:
+// - The explosion affects all 8 surrounding tiles + the NecroPawn itself.
+// - There is no confirmation dialog — detonation occurs instantly after the third click.
+// - This ability overrides all normal movement once sacrifice mode is engaged.
+//
+// Usage:
+// - Integrated with the global `clickHandler`, `highlight` system, and board state management.
+// - A powerful tactical unit capable of punishing dense clusters of enemies — or misused, friendly fire.
 
-Clicking once highlights its moves. Clicking a second time activates sacrifice mode. Clicking again 
-confirms and triggers the explosion. To cancel, select another square instead.
-*/
 
 import { getPieceAt } from '~/pixi/utils';
 import { setSacrificeMode, sacrificeMode, setHighlights } from '~/state/gameState';

--- a/frontend/src/pixi/pieces/necro/NecroPawn.js
+++ b/frontend/src/pixi/pieces/necro/NecroPawn.js
@@ -1,0 +1,119 @@
+/*
+Summary:
+The NecroPawn is a corrupted pawn that serves the Necromancer race. It can march forward like any 
+ordinary pawn, but beneath its humble shell lies a terrifying ability — the power to self-destruct 
+in a burst of necrotic energy, obliterating everything around it, including allies.
+
+Clicking once highlights its moves. Clicking a second time activates sacrifice mode. Clicking again 
+confirms and triggers the explosion. To cancel, select another square instead.
+*/
+
+import { getPieceAt } from '~/pixi/utils';
+import { setSacrificeMode, sacrificeMode, setHighlights } from '~/state/gameState';
+
+/**
+ * Highlight valid moves for a NecroPawn.
+ * 
+ * This includes:
+ * - Standard pawn moves (single/double step forward)
+ * - Diagonal captures
+ * - Self square in red (for initiating sacrifice)
+ * - If in sacrifice mode, highlights AoE capture squares in red
+ *
+ * @param {Object} piece - The NecroPawn piece object.
+ * @param {Function} addHighlight - Function to register highlight on a tile.
+ * @param {Array} allPieces - Array of all current pieces on the board.
+ */
+export function highlightMoves(piece, addHighlight, allPieces) {
+	const forward = piece.color === 'White' ? 1 : -1;
+	const row = piece.row;
+	const col = piece.col;
+
+	const inSacrificeMode = sacrificeMode()?.id === piece.id;
+
+	// Highlight self: blue (initial), red (if in sacrifice mode)
+	addHighlight(row, col, inSacrificeMode ? 0xff0000 : 0x00ffff);
+
+	// AoE preview if in sacrifice mode
+	if (inSacrificeMode) {
+		console.log("in sacrifice mode");
+		getSurroundingTiles(row, col).forEach(({ row: r, col: c }) => {
+			if (r >= 0 && r < 8 && c >= 0 && c < 8) {
+				addHighlight(r, c, 0xff0000);
+			}
+		});
+		return;
+	}
+
+	// Normal movement
+	const singleStep = { row: row + forward, col };
+	if (!getPieceAt(singleStep, allPieces)) {
+		addHighlight(singleStep.row, singleStep.col);
+	}
+
+	const startRow = piece.color === 'White' ? 1 : 6;
+	const doubleStep = { row: row + 2 * forward, col };
+	if (
+		row === startRow &&
+		!getPieceAt(singleStep, allPieces) &&
+		!getPieceAt(doubleStep, allPieces)
+	) {
+		addHighlight(doubleStep.row, doubleStep.col);
+	}
+
+	for (const offset of [-1, 1]) {
+		const target = { row: row + forward, col: col + offset };
+		if (
+			target.row >= 0 && target.row < 8 &&
+			target.col >= 0 && target.col < 8
+		) {
+			const targetPiece = getPieceAt(target, allPieces);
+			if (targetPiece && targetPiece.color !== piece.color) {
+				addHighlight(target.row, target.col, 0xff0000);
+			}
+		}
+	}
+}
+  
+
+/**
+ * Executes the sacrifice ability: removes all pieces in 8 surrounding tiles + the NecroPawn itself.
+ *
+ * @param {Object} necroPawn - The NecroPawn piece object.
+ * @param {Function} setPieces - Setter for the global pieces signal.
+ * @param {Array} allPieces - The current list of pieces on the board.
+ */
+export function performNecroPawnSacrifice(necroPawn, setPiecesFn, allPieces) {
+  const captureArea = getSurroundingTiles(necroPawn.row, necroPawn.col);
+  captureArea.push({ row: necroPawn.row, col: necroPawn.col });
+
+  const survivors = allPieces.filter(piece => {
+    return !captureArea.some(pos =>
+      pos.row === piece.row && pos.col === piece.col
+    );
+  });
+
+  setPiecesFn(survivors);
+  setHighlights([]);
+  setSacrificeMode(null);
+}
+
+/**
+ * Returns all 8 adjacent tile positions around a square.
+ *
+ * @param {number} row - Row index of the center tile.
+ * @param {number} col - Column index of the center tile.
+ * @returns {Array<{row: number, col: number}>}
+ */
+function getSurroundingTiles(row, col) {
+  return [
+    { row: row - 1, col: col - 1 },
+    { row: row - 1, col: col },
+    { row: row - 1, col: col + 1 },
+    { row: row,     col: col - 1 },
+    { row: row,     col: col + 1 },
+    { row: row + 1, col: col - 1 },
+    { row: row + 1, col: col },
+    { row: row + 1, col: col + 1 },
+  ];
+}

--- a/frontend/src/state/gameState.js
+++ b/frontend/src/state/gameState.js
@@ -4,6 +4,8 @@ export const [selectedSquare, setSelectedSquare] = createSignal(null);
 export const [highlights, setHighlights] = createSignal([]);
 export const [resurrectionTargets, setResurrectionTargets] = createSignal([]);
 export const [pendingResurrectionColor, setPendingResurrectionColor] = createSignal(null);
+export const [sacrificeMode, setSacrificeMode] = createSignal(null);
+export const [sacrificeArmed, setSacrificeArmed] = createSignal(false);
 
 
 // Corrected standard chess layout
@@ -35,12 +37,12 @@ export const [pieces, setPieces] = createSignal([
   { id: 22, type: "Necromancer", color: "Black", row: 7, col: 5 },
   { id: 23, type: "Knight", color: "Black", row: 7, col: 6 },
   { id: 24, type: "Rook", color: "Black", row: 7, col: 7 },
-  { id: 25, type: "Pawn", color: "Black", row: 6, col: 0 },
-  { id: 26, type: "Pawn", color: "Black", row: 6, col: 1 },
-  { id: 27, type: "Pawn", color: "Black", row: 6, col: 2 },
-  { id: 28, type: "Pawn", color: "Black", row: 6, col: 3 },
-  { id: 29, type: "Pawn", color: "Black", row: 6, col: 4 },
-  { id: 30, type: "Pawn", color: "Black", row: 6, col: 5 },
-  { id: 31, type: "Pawn", color: "Black", row: 6, col: 6 },
-  { id: 32, type: "Pawn", color: "Black", row: 6, col: 7 },
+  { id: 25, type: "NecroPawn", color: "Black", row: 6, col: 0 },
+  { id: 26, type: "NecroPawn", color: "Black", row: 6, col: 1 },
+  { id: 27, type: "NecroPawn", color: "Black", row: 6, col: 2 },
+  { id: 28, type: "NecroPawn", color: "Black", row: 6, col: 3 },
+  { id: 29, type: "NecroPawn", color: "Black", row: 6, col: 4 },
+  { id: 30, type: "NecroPawn", color: "Black", row: 6, col: 5 },
+  { id: 31, type: "NecroPawn", color: "Black", row: 6, col: 6 },
+  { id: 32, type: "NecroPawn", color: "Black", row: 6, col: 7 },
 ]);


### PR DESCRIPTION
This pull request introduces the `NecroPawn` piece to the chess game, along with its unique "Sacrifice" ability, and integrates it into the game's logic, interactions, and state management. The changes include adding the piece's functionality, updating the click handler to support its behavior, and modifying the game state to accommodate its special mechanics.

### Additions and Enhancements for `NecroPawn`:

* **New Piece Definition**: Added the `NecroPawn` piece, a special pawn with a "Sacrifice" ability that allows it to detonate and destroy surrounding pieces. This includes movement logic, highlighting rules, and the detonation mechanism. (`frontend/src/pixi/pieces/necro/NecroPawn.js`)

* **State Management Updates**: Introduced new signals `sacrificeMode` and `sacrificeArmed` to track the `NecroPawn`'s special ability state. The initial board state was updated to replace standard pawns with `NecroPawn` pieces for the black side. (`frontend/src/state/gameState.js`) [[1]](diffhunk://#diff-3a25ba3f5bd42c16ca7bf6a926d221b3df739b255353223fbfa6a40ba5668593R7-R8) [[2]](diffhunk://#diff-3a25ba3f5bd42c16ca7bf6a926d221b3df739b255353223fbfa6a40ba5668593L38-R47)

### Integration with Game Logic:

* **Highlighting System**: Updated the `highlight.js` module to include the `NecroPawn` in the `pieceLogicMap`, enabling its highlighting logic to be recognized and executed. (`frontend/src/pixi/highlight.js`) [[1]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR8-R9) [[2]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR23)

* **Click Handler Enhancements**: Modified the `handleSquareClick` function to handle the `NecroPawn`'s unique behavior. This includes entering sacrifice mode, detonating the piece, and clearing relevant states after the detonation. (`frontend/src/pixi/interactions/clickHandler.js`) [[1]](diffhunk://#diff-7904b645c42e8756b7d8adb243d3104ab79c329bcb448cc8f6b7c7ebde069107L11-R21) [[2]](diffhunk://#diff-7904b645c42e8756b7d8adb243d3104ab79c329bcb448cc8f6b7c7ebde069107R40-R75) [[3]](diffhunk://#diff-7904b645c42e8756b7d8adb243d3104ab79c329bcb448cc8f6b7c7ebde069107L64-L129)

These changes collectively introduce a new tactical element to the game, allowing players to strategically use the `NecroPawn` for area-of-effect attacks while balancing the risks of sacrificing their own piece.