### PR TITLE
Add QueenOfBones piece and her revive mechanic

### DIFF
--- a/frontend/src/pixi/highlight.js
+++ b/frontend/src/pixi/highlight.js
@@ -9,7 +9,7 @@ import * as NecroPawn from '~/pixi/pieces/necro/NecroPawn';
 import * as DeadLauncher from '~/pixi/pieces/necro/DeadLauncher';
 import * as GhostKnight from '~/pixi/pieces/necro/GhostKnight';
 import * as GhoulKing from '~/pixi/pieces/necro/GhoulKing';
-
+import * as QueenOfBones from '~/pixi/pieces/necro/QueenOfBones';
 
 /**
  * Mapping of piece types to their associated highlight logic modules.
@@ -27,6 +27,7 @@ const pieceLogicMap = {
   DeadLauncher,
   GhostKnight,
   GhoulKing,
+  QueenOfBones,
 };
 
 /**

--- a/frontend/src/pixi/logic/handlePieceMove.js
+++ b/frontend/src/pixi/logic/handlePieceMove.js
@@ -55,7 +55,7 @@ export async function handlePieceMove(destination, pixiApp) {
   const movedVersion = { ...movingPiece, row: destination.row, col: destination.col };
   applyStunEffect(movedVersion, updatedPieces);
   
-  // Handle resurrection prompts (e.g. Necromancer ability)
+  // Handle resurrection prompts (e.g. Necromancer / QueenOfBones ability)
   triggerResurrectionPrompt(movingPiece, capturedPiece, destination, updatedPieces);
 
   // Redraw the board

--- a/frontend/src/pixi/pieces/necro/QueenOfBones.js
+++ b/frontend/src/pixi/pieces/necro/QueenOfBones.js
@@ -1,0 +1,75 @@
+// Description: Logic module for the QueenOfBones piece, a level 2 Queen from the Necromancer Guild.
+//
+// Main Functions:
+// - highlightMoves(queenOfBones, addHighlight, allPieces):
+//     Highlights all valid movement and capture tiles using standard Queen movement logic.
+//
+// - triggerQueenOfBonesRevival(updatedPieces, queenColor):
+//     If a QueenOfBones is captured and at least two friendly Pawns or NecroPawns are present,
+//     prompts the player to select two of them for sacrifice in order to respawn the Queen.
+//
+// Special Features or Notes:
+// - The QueenOfBones is a custom level 2 Queen piece unique to the Necromancer Guild.
+// - It moves like a standard Queen (diagonal, horizontal, vertical — any number of spaces).
+// - It can capture enemy pieces by moving into their square.
+// - Upon being captured, the QueenOfBones triggers a special revival ability:
+//     - If the player controls at least two friendly Pawns or NecroPawns, those units can be sacrificed.
+//     - The player is prompted to select two such pieces by clicking them when they are highlighted in purple.
+//     - Once two pawns have been sacrificed, the QueenOfBones respawns automatically at its original spawn point
+//       (d1 or d8 depending on color), but only if the square is unoccupied.
+// - If the spawn square is occupied, the resurrection fails silently.
+// - The sacrifice prompt is managed using `resurrectionTargets`, `pendingResurrectionColor`, and a
+//   `isInSacrificeSelectionMode` flag from the central game state.
+//
+// Usage or Context:
+// - This module integrates with the PixiJS highlight engine and resurrection handler.
+// - Movement is delegated to the standard Queen logic.
+// - Sacrifice and respawn behavior is triggered from `triggerResurrectionPrompt()` in `handlePieceMove.js`.
+
+import {
+    setResurrectionTargets,
+    setPendingResurrectionColor,
+    setIsInSacrificeSelectionMode,
+  } from '~/state/gameState';
+  
+  import { highlightMoves as highlightStandardQueenMoves } from '~/pixi/pieces/basic/Queen';
+  
+  /**
+   * Highlights valid movement and capture tiles for the QueenOfBones.
+   * Delegates to standard Queen movement logic.
+   *
+   * @param {Object} queenOfBones - The QueenOfBones piece.
+   * @param {Function} addHighlight - Callback to register highlight objects.
+   * @param {Array} allPieces - All pieces currently on the board.
+   */
+  export function highlightMoves(queenOfBones, addHighlight, allPieces) {
+    highlightStandardQueenMoves(queenOfBones, addHighlight, allPieces);
+  }
+  
+  /**
+   * Triggers revival prompt for QueenOfBones after it is captured.
+   * If 2 or more friendly pawns exist, highlights them for sacrifice.
+   *
+   * @param {Array} updatedPieces - All board pieces after the QueenOfBones has been captured.
+   * @param {string} queenColor - The color of the QueenOfBones that was captured.
+   */
+  export function triggerQueenOfBonesRevival(updatedPieces, queenColor) {
+    const eligiblePawns = updatedPieces.filter(
+      piece =>
+        piece.color === queenColor &&
+        (piece.type === 'Pawn' || piece.type === 'NecroPawn')
+    );
+  
+    if (eligiblePawns.length >= 2) {
+      const sacrificeTiles = eligiblePawns.map(pawn => ({
+        row: pawn.row,
+        col: pawn.col,
+        color: 0x880088, // Purple highlight for sacrifice prompt
+      }));
+  
+      setResurrectionTargets(sacrificeTiles);
+      setPendingResurrectionColor(queenColor);
+      setIsInSacrificeSelectionMode(true);
+    }
+  }
+  

--- a/frontend/src/state/gameState.js
+++ b/frontend/src/state/gameState.js
@@ -8,6 +8,7 @@ export const [sacrificeMode, setSacrificeMode] = createSignal(null);
 export const [sacrificeArmed, setSacrificeArmed] = createSignal(false);
 export const [launchMode, setLaunchMode] = createSignal(null);
 export const [isInLoadingMode, setIsInLoadingMode] = createSignal(false);
+export const [isInSacrificeSelectionMode, setIsInSacrificeSelectionMode] = createSignal(false);
 
 
 // Corrected standard chess layout
@@ -34,7 +35,7 @@ export const [pieces, setPieces] = createSignal([
   { id: 17, type: "DeadLauncher", color: "Black", row: 7, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0  },
   { id: 18, type: "GhostKnight", color: "Black", row: 7, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 19, type: "Necromancer", color: "Black", row: 7, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 20, type: "Queen", color: "Black", row: 7, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 20, type: "QueenOfBones", color: "Black", row: 7, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 21, type: "GhoulKing", color: "Black", row: 7, col: 4, pawnLoaded: false, stunned: false, raisesLeft: 1 },
   { id: 22, type: "Necromancer", color: "Black", row: 7, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 23, type: "GhostKnight", color: "Black", row: 7, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0 },


### PR DESCRIPTION
This pull request introduces the `QueenOfBones` piece, a new level-2 Queen for the Necromancer Guild, along with its unique movement, capture, and resurrection mechanics. The changes include updates to highlight logic, game state, and resurrection handling to support the new piece.

### Integration of the `QueenOfBones` Piece

**Core functionality:**
* Added the `QueenOfBones` logic module with movement and resurrection mechanics. Upon capture, it can be revived by sacrificing two friendly pawns or `NecroPawns` if available. The piece respawns at its original spawn point if unoccupied. (`frontend/src/pixi/pieces/necro/QueenOfBones.js`)

**Highlight and mapping updates:**
* Imported `QueenOfBones` into the highlight logic and added it to the `pieceLogicMap` for proper integration with the highlighting system. (`frontend/src/pixi/highlight.js`) [[1]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edL12-R12) [[2]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR30)

### Resurrection Handling Enhancements

* Updated the `handleResurrectionClick` function to support pawn sacrifices for reviving the `QueenOfBones`. Added logic to track sacrifices, handle respawn conditions, and reset state after a successful or failed revival. (`frontend/src/pixi/logic/handleResurrectionClick.js`) [[1]](diffhunk://#diff-b6e15d0417952b08fcd1bd13266cf3003d41c531a2eeb8f92344e8aaa139ba16R5-R98) [[2]](diffhunk://#diff-b6e15d0417952b08fcd1bd13266cf3003d41c531a2eeb8f92344e8aaa139ba16L36-R107)
* Enhanced `triggerResurrectionPrompt` to handle the `QueenOfBones` revival prompt when it is captured. (`frontend/src/pixi/logic/handleResurrectionClick.js`) [[1]](diffhunk://#diff-b6e15d0417952b08fcd1bd13266cf3003d41c531a2eeb8f92344e8aaa139ba16L47-R125) [[2]](diffhunk://#diff-b6e15d0417952b08fcd1bd13266cf3003d41c531a2eeb8f92344e8aaa139ba16R135-R138)

### Game State Updates

* Introduced `isInSacrificeSelectionMode` and its setter to track the state of the sacrifice prompt during the `QueenOfBones` revival process. (`frontend/src/state/gameState.js`)
* Replaced the standard Queen in the initial piece setup with the `QueenOfBones` for the Necromancer Guild. (`frontend/src/state/gameState.js`)

### Minor Updates

* Updated comments and documentation across functions to reflect the new `QueenOfBones` mechanics, ensuring clarity for future maintenance. (`frontend/src/pixi/logic/handlePieceMove.js`)