### PR TITLE
Add PawnHopper piece

### DIFF
--- a/frontend/src/pixi/highlight.js
+++ b/frontend/src/pixi/highlight.js
@@ -10,6 +10,7 @@ import * as DeadLauncher from '~/pixi/pieces/necro/DeadLauncher';
 import * as GhostKnight from '~/pixi/pieces/necro/GhostKnight';
 import * as GhoulKing from '~/pixi/pieces/necro/GhoulKing';
 import * as QueenOfBones from '~/pixi/pieces/necro/QueenOfBones';
+import * as PawnHopper from '~/pixi/pieces/beasts/PawnHopper';
 
 /**
  * Mapping of piece types to their associated highlight logic modules.
@@ -28,6 +29,7 @@ const pieceLogicMap = {
   GhostKnight,
   GhoulKing,
   QueenOfBones,
+  PawnHopper,
 };
 
 /**

--- a/frontend/src/pixi/pieces/beasts/pawnHopper.js
+++ b/frontend/src/pixi/pieces/beasts/pawnHopper.js
@@ -1,0 +1,118 @@
+// Filename: PawnHopper.js
+// Description: Logic module for the PawnHopper, a level 2 pawn from the BeastMaster Guild.
+//
+// Main Functions:
+// - highlightMoves(pawnHopper, addHighlight, allPieces):
+//     Highlights all valid movement and capture tiles for the PawnHopper, including two-step hop captures.
+// - applyHopperCapture(from, destination, allPieces, color):
+//     If a PawnHopper performs a 2-tile forward move, captures the enemy piece it hops over.
+// - handlePawnHopperPostMove(from, destination, movedPieces, movingPiece, color):
+//     Post-move logic handler that delegates to applyHopperCapture if needed.
+//
+// Special Features or Notes:
+// - The PawnHopper can move forward 1 or 2 tiles regardless of move history.
+// - Captures diagonally like a standard pawn.
+// - Can also capture by hopping forward 2 tiles over an enemy unit (only if square behind is empty).
+
+import { highlightMoves as highlightStandardPawnMoves } from '~/pixi/pieces/basic/Pawn';
+import { getPieceAt } from '~/pixi/utils';
+
+/**
+ * Highlights all valid moves for a PawnHopper piece.
+ * Extends normal pawn behavior with a forward hop capture mechanic.
+ *
+ * @param {Object} pawnHopper - The PawnHopper piece being selected.
+ * @param {Function} addHighlight - Callback used to push highlight tiles.
+ * @param {Array} allPieces - Current state of all pieces on the board.
+ */
+export function highlightMoves(pawnHopper, addHighlight, allPieces) {
+  const direction = pawnHopper.color === 'White' ? 1 : -1;
+  const oneStepRow = pawnHopper.row + direction;
+  const twoStepRow = pawnHopper.row + 2 * direction;
+  const column = pawnHopper.col;
+
+  // Inherit single-step and diagonal capture logic from standard Pawn
+  highlightStandardPawnMoves(pawnHopper, addHighlight, allPieces);
+
+  // Add highlight for 2-step forward movement (hop capture)
+  const squareAhead = getPieceAt({ row: oneStepRow, col: column }, allPieces);
+  const squareTwoAhead = getPieceAt({ row: twoStepRow, col: column }, allPieces);
+
+  if (!squareTwoAhead) {
+    const isHopCapture = squareAhead && squareAhead.color !== pawnHopper.color;
+    const highlightColor = isHopCapture ? 0xff0000 : undefined;
+    addHighlight(twoStepRow, column, highlightColor);
+  }
+}
+
+/**
+ * If a PawnHopper hops 2 tiles forward and there's an enemy between, remove it.
+ *
+ * @param {{ row: number, col: number }} from - Origin square of the piece.
+ * @param {{ row: number, col: number }} destination - Target square after movement.
+ * @param {Array} allPieces - Current board pieces after movement.
+ * @param {string} color - Color of the moving PawnHopper ('White' or 'Black').
+ * @returns {{ updatedPieces: Array, captured: Object|null }} - New board and optional captured piece.
+ */
+export function applyHopperCapture(from, destination, allPieces, color) {
+  const direction = color === 'White' ? 1 : -1;
+  const isTwoStepForward = Math.abs(destination.row - from.row) === 2;
+  const sameColumn = destination.col === from.col;
+
+  if (isTwoStepForward && sameColumn) {
+    const hoppedRow = from.row + direction;
+    const hoppedEnemy = getPieceAt({ row: hoppedRow, col: from.col }, allPieces);
+
+    if (hoppedEnemy && hoppedEnemy.color !== color) {
+      const filteredBoard = allPieces.filter(
+        piece => !(piece.row === hoppedRow && piece.col === from.col)
+      );
+      return {
+        updatedPieces: filteredBoard,
+        captured: hoppedEnemy,
+      };
+    }
+  }
+
+  return {
+    updatedPieces: allPieces,
+    captured: null,
+  };
+}
+
+/**
+ * Handles post-move PawnHopper effects (hop-capture).
+ *
+ * @param {{ row: number, col: number }} from - Square the piece moved from.
+ * @param {{ row: number, col: number }} destination - Square the piece moved to.
+ * @param {Array} movedPieces - Current piece list after basic movement.
+ * @param {Object} movingPiece - The PawnHopper piece that just moved.
+ * @param {string} color - Color of the PawnHopper.
+ * @returns {{ updatedPieces: Array, captured: Object|null }} Resulting state and capture (if any).
+ */
+export function handlePawnHopperPostMove(from, destination, movedPieces, movingPiece, color) {
+  if (movingPiece.type !== 'PawnHopper') {
+    return {
+      updatedPieces: movedPieces,
+      captured: null,
+    };
+  }
+
+  const direction = color === 'White' ? 1 : -1;
+  const isTwoStepForward = Math.abs(destination.row - from.row) === 2;
+  const sameColumn = destination.col === from.col;
+
+  if (isTwoStepForward && sameColumn) {
+    const hoppedRow = from.row + direction;
+    const hoppedPiece = getPieceAt({ row: hoppedRow, col: from.col }, movedPieces);
+
+    if (hoppedPiece && hoppedPiece.color !== color) {
+      return applyHopperCapture(from, destination, movedPieces, color);
+    }
+  }
+
+  return {
+    updatedPieces: movedPieces,
+    captured: null,
+  };
+}

--- a/frontend/src/state/gameState.js
+++ b/frontend/src/state/gameState.js
@@ -9,6 +9,7 @@ export const [sacrificeArmed, setSacrificeArmed] = createSignal(false);
 export const [launchMode, setLaunchMode] = createSignal(null);
 export const [isInLoadingMode, setIsInLoadingMode] = createSignal(false);
 export const [isInSacrificeSelectionMode, setIsInSacrificeSelectionMode] = createSignal(false);
+export const [capturedPiece, setCapturedPiece] = createSignal(null);
 
 
 // Corrected standard chess layout
@@ -22,14 +23,14 @@ export const [pieces, setPieces] = createSignal([
   { id: 6, type: "Bishop", color: "White", row: 0, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 7, type: "Knight", color: "White", row: 0, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 8, type: "Rook", color: "White", row: 0, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 9,  type: "Pawn", color: "White", row: 1, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 10, type: "Pawn", color: "White", row: 1, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 11, type: "Pawn", color: "White", row: 1, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 12, type: "Pawn", color: "White", row: 1, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 13, type: "Pawn", color: "White", row: 1, col: 4, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 14, type: "Pawn", color: "White", row: 1, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 15, type: "Pawn", color: "White", row: 1, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 16, type: "Pawn", color: "White", row: 1, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 9,  type: "PawnHopper", color: "White", row: 1, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 10, type: "PawnHopper", color: "White", row: 1, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 11, type: "PawnHopper", color: "White", row: 1, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 12, type: "PawnHopper", color: "White", row: 1, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 13, type: "PawnHopper", color: "White", row: 1, col: 4, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 14, type: "PawnHopper", color: "White", row: 1, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 15, type: "PawnHopper", color: "White", row: 1, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 16, type: "PawnHopper", color: "White", row: 1, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0 },
 
   // Black Pieces (bottom of the board)
   { id: 17, type: "DeadLauncher", color: "Black", row: 7, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0  },


### PR DESCRIPTION
This pull request introduces the `PawnHopper` piece from the BeastMaster Guild, adding new movement and capture mechanics. Changes include integrating the `PawnHopper` into the game state, movement logic, and highlight functionality, as well as implementing its unique hop-capture ability.

### Integration of `PawnHopper`:

* **Highlight and Movement Logic**:
  - Added the `PawnHopper` module with functions to handle its unique two-step hop capture and movement mechanics, including `highlightMoves`, `applyHopperCapture`, and `handlePawnHopperPostMove` (`frontend/src/pixi/pieces/beasts/pawnHopper.js`).
  - Updated `pieceLogicMap` in `frontend/src/pixi/highlight.js` to include `PawnHopper` for highlight logic. [[1]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR13) [[2]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR32)

* **Game State Updates**:
  - Replaced standard pawns with `PawnHopper` pieces in the initial game state (`frontend/src/state/gameState.js`).
  - Introduced a new `capturedPiece` signal to track captured pieces, supporting the `PawnHopper`'s mechanics.

### Movement Logic Enhancements:
* Refactored `handlePieceMove` in `frontend/src/pixi/logic/handlePieceMove.js` to integrate the `PawnHopper`'s post-move logic, ensuring its hop-capture ability is applied during gameplay.