### PR TITLE
Add both beastknight and beastdruid pieces

### DIFF
--- a/frontend/src/pixi/highlight.js
+++ b/frontend/src/pixi/highlight.js
@@ -11,6 +11,8 @@ import * as GhostKnight from '~/pixi/pieces/necro/GhostKnight';
 import * as GhoulKing from '~/pixi/pieces/necro/GhoulKing';
 import * as QueenOfBones from '~/pixi/pieces/necro/QueenOfBones';
 import * as PawnHopper from '~/pixi/pieces/beasts/PawnHopper';
+import * as BeastKnight from '~/pixi/pieces/beasts/BeastKnight';
+import * as BeastDruid from '~/pixi/pieces/beasts/BeastDruid';
 
 /**
  * Mapping of piece types to their associated highlight logic modules.
@@ -30,6 +32,8 @@ const pieceLogicMap = {
   GhoulKing,
   QueenOfBones,
   PawnHopper,
+  BeastKnight,
+  BeastDruid,
 };
 
 /**

--- a/frontend/src/pixi/pieces/beasts/BeastDruid.js
+++ b/frontend/src/pixi/pieces/beasts/BeastDruid.js
@@ -1,0 +1,34 @@
+// Filename: beastDruid.js
+// Description: Logic module for the BeastDruid, a level 2 Bishop from the BeastMaster Guild.
+//
+// Main Functions:
+// - highlightMoves(beastDruid, addHighlight, allPieces):
+//     Highlights all valid movement and capture tiles for the BeastDruid,
+//     combining diagonal Bishop movement and 1-tile perimeter King movement.
+//
+// Special Features:
+// - The BeastDruid is a level 2 Bishop-type unit that belongs to the BeastMaster Guild.
+// - It inherits full Bishop movement (unlimited diagonal range, path must be clear).
+// - It also inherits full King movement (one square in any direction).
+// - Like all units, it captures by moving into a tile occupied by an enemy unit.
+// - Highlighted tiles are yellow for movement and red for capture.
+// - Movement is blocked by friendly units and blocked paths.
+//
+// Usage or Context:
+// - This logic module is plugged into the PixiJS board renderer to determine highlightable tiles.
+// - Movement legality is reused from base Bishop and King logic using shared highlight methods.
+
+import { highlightMoves as highlightKingMoves } from '~/pixi/pieces/basic/King';
+import { highlightMoves as highlightBishopMoves } from '~/pixi/pieces/basic/Bishop';
+
+/**
+ * Highlights all valid moves for the BeastDruid.
+ * Combines Bishop (diagonal) and King (1-tile perimeter) logic.
+ * @param {Object} beastDruid - The BeastDruid piece.
+ * @param {Function} addHighlight - Function to add highlight tiles.
+ * @param {Array} allPieces - Current pieces on the board.
+ */
+export function highlightMoves(beastDruid, addHighlight, allPieces) {
+  highlightBishopMoves(beastDruid, addHighlight, allPieces);
+  highlightKingMoves(beastDruid, addHighlight, allPieces);
+}

--- a/frontend/src/pixi/pieces/beasts/BeastKnight.js
+++ b/frontend/src/pixi/pieces/beasts/BeastKnight.js
@@ -1,0 +1,56 @@
+// Filename: beastKnight.js
+// Description: Logic module for the BeastKnight piece, a level 2 Knight from the BeastMaster Guild.
+//
+// Main Functions:
+// - highlightMoves(beastKnight, addHighlight, allPieces):
+//     Highlights all valid movement and capture tiles for the BeastKnight.
+//
+// Special Features:
+// - Moves in an extended L-shape: 3 squares in one direction and 1 in the other (3/1 or 1/3).
+// - Ignores intervening pieces; only cares about the destination.
+// - Captures by landing on an enemy unit.
+//
+// Usage:
+// - Used by the PixiJS board renderer to determine valid tiles when a BeastKnight is selected.
+
+import { getPieceAt } from '~/pixi/utils';
+
+/**
+ * Highlights all valid moves for the BeastKnight.
+ * Extended L-shaped logic: (3,1) and (1,3) movement.
+ *
+ * @param {Object} beastKnight - The piece to evaluate.
+ * @param {Function} addHighlight - Function to add highlights.
+ * @param {Array} allPieces - Current state of the board.
+ */
+export function highlightMoves(beastKnight, addHighlight, allPieces) {
+  const { row, col, color } = beastKnight;
+
+  // All 8 possible BeastKnight L-shaped moves
+  const moveOffsets = [
+    { dRow: 3, dCol: 1 },
+    { dRow: 3, dCol: -1 },
+    { dRow: -3, dCol: 1 },
+    { dRow: -3, dCol: -1 },
+    { dRow: 1, dCol: 3 },
+    { dRow: 1, dCol: -3 },
+    { dRow: -1, dCol: 3 },
+    { dRow: -1, dCol: -3 },
+  ];
+
+  for (const { dRow, dCol } of moveOffsets) {
+    const targetRow = row + dRow;
+    const targetCol = col + dCol;
+
+    // Board bounds check
+    if (targetRow < 0 || targetRow >= 8 || targetCol < 0 || targetCol >= 8) continue;
+
+    const targetPiece = getPieceAt({ row: targetRow, col: targetCol }, allPieces);
+
+    if (!targetPiece) {
+      addHighlight(targetRow, targetCol); // Standard move
+    } else if (targetPiece.color !== color) {
+      addHighlight(targetRow, targetCol, 0xff0000); // Capture
+    }
+  }
+}

--- a/frontend/src/state/gameState.js
+++ b/frontend/src/state/gameState.js
@@ -16,12 +16,12 @@ export const [capturedPiece, setCapturedPiece] = createSignal(null);
 export const [pieces, setPieces] = createSignal([
   // White Pieces (top of the board)
   { id: 1, type: "Rook", color: "White", row: 0, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 2, type: "Knight", color: "White", row: 0, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 3, type: "Bishop", color: "White", row: 0, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 2, type: "BeastKnight", color: "White", row: 0, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 3, type: "BeastDruid", color: "White", row: 0, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 4, type: "Queen", color: "White", row: 0, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 5, type: "King", color: "White", row: 0, col: 4, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 6, type: "Bishop", color: "White", row: 0, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 7, type: "Knight", color: "White", row: 0, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 6, type: "BeastDruid", color: "White", row: 0, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 7, type: "BeastKnight", color: "White", row: 0, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 8, type: "Rook", color: "White", row: 0, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 9,  type: "PawnHopper", color: "White", row: 1, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 10, type: "PawnHopper", color: "White", row: 1, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0 },


### PR DESCRIPTION
This pull request introduces two new BeastMaster Guild pieces, `BeastKnight` and `BeastDruid`, to the game. It includes their logic modules, updates the piece logic mapping, and integrates the new pieces into the game state.

### New Piece Logic Modules:

* Added `BeastDruid` logic in `frontend/src/pixi/pieces/beasts/BeastDruid.js`. The `BeastDruid` combines diagonal Bishop movement with one-tile King movement, highlighting valid moves and captures.
* Added `BeastKnight` logic in `frontend/src/pixi/pieces/beasts/BeastKnight.js`. The `BeastKnight` moves in an extended L-shape (3/1 or 1/3) and highlights valid moves and captures.

### Integration into Highlight Logic:

* Imported `BeastKnight` and `BeastDruid` into `frontend/src/pixi/highlight.js` and added them to the `pieceLogicMap` for highlight functionality. [[1]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR14-R15) [[2]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR35-R36)

### Game State Updates:

* Replaced standard `Knight` and `Bishop` pieces with `BeastKnight` and `BeastDruid` in the initial game state in `frontend/src/state/gameState.js`.