### PR TITLE
Add frog king piece

### DIFF
--- a/frontend/src/pixi/highlight.js
+++ b/frontend/src/pixi/highlight.js
@@ -14,6 +14,7 @@ import * as PawnHopper from '~/pixi/pieces/beasts/PawnHopper';
 import * as BeastKnight from '~/pixi/pieces/beasts/BeastKnight';
 import * as BeastDruid from '~/pixi/pieces/beasts/BeastDruid';
 import * as BoulderThrower from '~/pixi/pieces/beasts/BoulderThrower';
+import * as FrogKing from '~/pixi/pieces/beasts/FrogKing';
 
 /**
  * Mapping of piece types to their associated highlight logic modules.
@@ -36,6 +37,7 @@ const pieceLogicMap = {
   BeastKnight,
   BeastDruid,
   BoulderThrower,
+  FrogKing,
 };
 
 /**

--- a/frontend/src/pixi/pieces/beasts/FrogKing.js
+++ b/frontend/src/pixi/pieces/beasts/FrogKing.js
@@ -1,0 +1,59 @@
+// Description: Logic module for the FrogKing, a level 2 King from the BeastMaster Guild.
+//
+// Main Functions:
+// - highlightMoves(frogKing, addHighlight, allPieces):
+//     Highlights all legal moves for the FrogKing, including standard King movement and extended orthogonal hops.
+//
+// Special Features:
+// - The FrogKing can move one square in any direction (like a standard King).
+// - It can also hop two squares orthogonally (up/down/left/right), ignoring intervening pieces.
+// - It captures by moving into a square occupied by an enemy unit.
+// - Hop movement allows capturing — it is not just evasive or positioning.
+// - Cannot hop diagonally.
+// - Does not support castling or other King-specific rules.
+// - Designed as a level 2 King from the BeastMaster faction.
+//
+// Usage:
+// - Import and use `highlightMoves` when this piece is selected to generate its valid move targets.
+
+import { getPieceAt } from '~/pixi/utils';
+import { highlightMoves as highlightKingMoves } from '~/pixi/pieces/basic/King';
+
+/**
+ * Highlights all valid movement and capture tiles for the FrogKing.
+ * Combines standard King movement with extended 2-tile orthogonal hops.
+ *
+ * @param {Object} frogKing - The FrogKing piece object.
+ * @param {Function} addHighlight - Function used to add a highlight (row, col, optional color).
+ * @param {Array} allPieces - All current game pieces on the board.
+ */
+export function highlightMoves(frogKing, addHighlight, allPieces) {
+    // Step 1: Normal King movement
+    highlightKingMoves(frogKing, addHighlight, allPieces);
+  
+    // Step 2: Add 2-tile orthogonal hops
+    const hopOffsets = [
+      { rowOffset: 2, colOffset: 0 },
+      { rowOffset: -2, colOffset: 0 },
+      { rowOffset: 0, colOffset: 2 },
+      { rowOffset: 0, colOffset: -2 }
+    ];
+  
+    for (const { rowOffset, colOffset } of hopOffsets) {
+      const targetRow = frogKing.row + rowOffset;
+      const targetCol = frogKing.col + colOffset;
+  
+      // Stay within bounds
+      if (targetRow < 0 || targetRow >= 8 || targetCol < 0 || targetCol >= 8) continue;
+  
+      const targetPiece = getPieceAt({ row: targetRow, col: targetCol }, allPieces);
+  
+      // Skip if occupied by a friendly piece
+      if (targetPiece && targetPiece.color === frogKing.color) continue;
+  
+      // Highlight enemy targets in red, empty squares default color
+      const color = targetPiece ? 0xff0000 : undefined;
+      addHighlight(targetRow, targetCol, color);
+    }
+  }
+  

--- a/frontend/src/state/gameState.js
+++ b/frontend/src/state/gameState.js
@@ -20,7 +20,7 @@ export const [pieces, setPieces] = createSignal([
   { id: 2, type: "BeastKnight", color: "White", row: 0, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 3, type: "BeastDruid", color: "White", row: 0, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 4, type: "Queen", color: "White", row: 0, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 5, type: "King", color: "White", row: 0, col: 4, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 5, type: "FrogKing", color: "White", row: 0, col: 4, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 6, type: "BeastDruid", color: "White", row: 0, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 7, type: "BeastKnight", color: "White", row: 0, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 8, type: "BoulderThrower", color: "White", row: 0, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0 },


### PR DESCRIPTION
This pull request introduces the new `FrogKing` piece to the game, including its logic, integration into the highlight system, and initial placement on the board. The most important changes involve defining the `FrogKing`'s unique movement and capture mechanics, updating the highlight logic to support it, and replacing the standard King with the `FrogKing` in the initial game state.

### Addition of the `FrogKing` piece:

* **New logic module for `FrogKing`:** Added `frontend/src/pixi/pieces/beasts/FrogKing.js` to define the `FrogKing`'s movement and capture rules. It combines standard King movement with the ability to hop two squares orthogonally, ignoring intervening pieces.

### Integration into the highlight system:

* **Highlight logic update:** Imported the `FrogKing` logic into `frontend/src/pixi/highlight.js` and added it to the `pieceLogicMap` to enable highlighting its legal moves. [[1]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR17) [[2]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR40)

### Updates to the game state:

* **Initial placement:** Replaced the standard King with the `FrogKing` in the initial game state in `frontend/src/state/gameState.js`.