### PR TITLE
Add Queen of domination piece

### DIFF
--- a/frontend/src/pixi/clickHandler.js
+++ b/frontend/src/pixi/clickHandler.js
@@ -4,6 +4,7 @@ import {
   pieces,
   highlights,
   setHighlights,
+  isInDominationMode,
 } from '~/state/gameState';
 
 import { highlightValidMovesForPiece } from '~/pixi/highlight';
@@ -16,6 +17,7 @@ import { drawBoard } from '~/pixi/drawBoard';
 import { handleDeadLauncherClick } from "./logic/handleDeadLauncherClick";
 import { handleGhoulKingClick } from "./logic/handleGhoulKingClick";
 import { handleBoulderThrowerClick } from './pieces/beasts/BoulderThrower';
+import { handleQueenOfDominationClick } from '~/pixi/logic/handleQueenOfDominationClick';
 
 
 /**
@@ -51,6 +53,18 @@ export async function handleSquareClick(rowIndex, columnIndex, pixiApp) {
       !isReclickedSelection
   );
 
+  // === 0. Check if in the middle of domination move
+  if (isInDominationMode()) {
+    const isClickedHighlighted = highlights().some(
+      highlight => highlight.row === rowIndex && highlight.col === columnIndex
+    );
+  
+    if (!isClickedHighlighted) {
+      console.log("Must move the dominated Queen first!");
+      return;
+    }
+  }
+
   // === 1. Check for NecroPawn sacrifice
   if (await handleSacrificeClick(rowIndex, columnIndex, pixiApp, currentPieces)) {
     return;
@@ -73,6 +87,11 @@ export async function handleSquareClick(rowIndex, columnIndex, pixiApp) {
 
   // 4. Handle BoulderThrower click logic
   if (await handleBoulderThrowerClick(rowIndex, columnIndex, pixiApp)) {
+    return;
+  }
+
+  // 5. Handle QueenOfDomination click logic
+  if (await handleQueenOfDominationClick(rowIndex, columnIndex, pixiApp)) {
     return;
   }
 

--- a/frontend/src/pixi/highlight.js
+++ b/frontend/src/pixi/highlight.js
@@ -15,6 +15,7 @@ import * as BeastKnight from '~/pixi/pieces/beasts/BeastKnight';
 import * as BeastDruid from '~/pixi/pieces/beasts/BeastDruid';
 import * as BoulderThrower from '~/pixi/pieces/beasts/BoulderThrower';
 import * as FrogKing from '~/pixi/pieces/beasts/FrogKing';
+import * as QueenOfDomination from '~/pixi/pieces/beasts/QueenOfDomination';
 
 /**
  * Mapping of piece types to their associated highlight logic modules.
@@ -38,6 +39,7 @@ const pieceLogicMap = {
   BeastDruid,
   BoulderThrower,
   FrogKing,
+  QueenOfDomination,
 };
 
 /**

--- a/frontend/src/pixi/logic/clearBoardState.js
+++ b/frontend/src/pixi/logic/clearBoardState.js
@@ -6,6 +6,7 @@ import {
 	setSacrificeMode,
 	setSacrificeArmed,
 	setLaunchMode,
+	setIsInDominationMode,
 } from '~/state/gameState';
 import { setIsInLoadingMode } from '../../state/gameState';
 
@@ -20,6 +21,7 @@ export async function clearBoardState({ preserveLaunch = false } = {}) {
 	setSacrificeMode(null);
 	setSacrificeArmed(false);
 	setIsInLoadingMode(false);
+	setIsInDominationMode(false);
 
 	if (!preserveLaunch) {
 		setLaunchMode(null);

--- a/frontend/src/pixi/logic/handleGhoulKingClick.js
+++ b/frontend/src/pixi/logic/handleGhoulKingClick.js
@@ -22,7 +22,6 @@ import { handleSquareClick } from '~/pixi/clickHandler';
  */
 export async function handleGhoulKingClick(row, col, pixiApp) {
   const currentPieces = pieces();
-  const clickedPiece = getPieceAt({ row, col }, currentPieces);
   const selectedCoord = selectedSquare();
   const selectedPiece = selectedCoord ? getPieceAt(selectedCoord, currentPieces) : null;
   const isRaiseTile = highlights().some(h => h.row === row && h.col === col && h.color === 0x00ffff);

--- a/frontend/src/pixi/logic/handleQueenOfDominationClick.js
+++ b/frontend/src/pixi/logic/handleQueenOfDominationClick.js
@@ -1,0 +1,116 @@
+import {
+  pieces,
+  setPieces,
+  setSelectedSquare,
+  selectedSquare,
+  setHighlights,
+} from '~/state/gameState';
+
+import { getPieceAt } from '~/pixi/utils';
+import { drawBoard } from '~/pixi/drawBoard';
+import { highlightValidMovesForPiece } from '~/pixi/highlight';
+import { applyDominationAbility, returnOriginalSprite } from '~/pixi/pieces/beasts/QueenOfDomination';
+import { handleSquareClick } from '~/pixi/clickHandler';
+
+/**
+ * Handles all click interactions related to QueenOfDomination:
+ * - First click selects the Queen and highlights adjacent friendly units.
+ * - Second click on an adjacent friendly unit transforms it into a Queen temporarily.
+ * - If the transformed Queen has no valid moves, reverts instantly.
+ * - Clicking on herself cancels the domination ability.
+ *
+ * @param {number} row - Row index of the clicked square.
+ * @param {number} col - Column index of the clicked square.
+ * @param {PIXI.Application} pixiApp - The PixiJS application instance.
+ * @returns {Promise<boolean>} True if handled, otherwise false.
+ */
+export async function handleQueenOfDominationClick(row, col, pixiApp) {
+  const currentPieces = pieces();
+  const selectedPosition = selectedSquare();
+  const queenPiece = selectedPosition ? getPieceAt(selectedPosition, currentPieces) : null;
+  const clickedPiece = getPieceAt({ row, col }, currentPieces);
+
+  // === Step 1: Ignore if no QueenOfDomination is selected
+  if (!queenPiece || queenPiece.type !== 'QueenOfDomination') {
+    return false;
+  }
+
+  // === Step 2: Ignore if Queen has already used her domination ability
+  if (queenPiece.pieceLoaded) {
+    return false;
+  }
+
+  // === Step 3: Process adjacent friendly click
+  if (clickedPiece && clickedPiece.color === queenPiece.color) {
+    
+    // --- Cancel if clicking herself again
+    if (clickedPiece.id === queenPiece.id) {
+      setSelectedSquare(null);
+      setHighlights([]);
+      await drawBoard(pixiApp, handleSquareClick);
+      return true;
+    }
+
+    // --- Apply domination ability
+    const updatedPieces = applyDominationAbility(queenPiece, clickedPiece, currentPieces);
+    setPieces(updatedPieces);
+
+    // --- Locate the newly dominated Queen
+    const dominatedPiece = updatedPieces.find(piece => piece.id === clickedPiece.id);
+
+    // === Step 4: If dominated piece has no valid moves, revert immediately
+    if (dominatedPiece && !hasValidMoves(dominatedPiece, updatedPieces)) {
+      console.log("Dominated piece has no moves. Reverting domination.");
+
+      const updatedQueenPiece = updatedPieces.find(piece => piece.id === queenPiece.id);
+      const revertedPieces = returnOriginalSprite(updatedQueenPiece, dominatedPiece, updatedPieces);
+      
+      setPieces(revertedPieces);
+      setSelectedSquare(null);
+      setHighlights([]);
+      await drawBoard(pixiApp, handleSquareClick);
+      return true;
+    }
+
+    // === Step 5: Force user to move the newly dominated Queen
+    if (dominatedPiece) {
+      setSelectedSquare({ row: dominatedPiece.row, col: dominatedPiece.col });
+
+      const newHighlights = [];
+      highlightValidMovesForPiece(
+        dominatedPiece,
+        (targetRow, targetCol, highlightColor) => {
+          newHighlights.push({
+            row: targetRow,
+            col: targetCol,
+            color: highlightColor
+          });
+        },
+        updatedPieces
+      );
+      setHighlights(newHighlights);
+    }
+
+    await drawBoard(pixiApp, handleSquareClick);
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Utility to determine if a piece has at least one valid move available.
+ *
+ * @param {Object} piece - The piece to check.
+ * @param {Array} allPieces - Current list of all board pieces.
+ * @returns {boolean} True if at least one valid move exists.
+ */
+function hasValidMoves(piece, allPieces) {
+  const validMoves = [];
+  highlightValidMovesForPiece(
+    piece,
+    (moveRow, moveCol) => validMoves.push({ row: moveRow, col: moveCol }),
+    allPieces
+  );
+  return validMoves.length > 0;
+}

--- a/frontend/src/pixi/pieces/beasts/QueenOfDomination.js
+++ b/frontend/src/pixi/pieces/beasts/QueenOfDomination.js
@@ -1,0 +1,121 @@
+// Filename: QueenOfDomination.js
+// Description: Logic module for QueenOfDomination, a Level 2 Queen piece from the BeastMaster Guild.
+//
+// Special Behavior:
+// - Moves like a normal Queen (orthogonal and diagonal).
+// - Can use a one-time ability per turn to "dominate" an adjacent friendly piece.
+// - The dominated piece becomes a Queen temporarily and must immediately move.
+// - If the dominated Queen has no valid moves, it instantly reverts to its original form.
+//
+// Main Functions:
+// - highlightMoves(queen, addHighlight, allPieces):
+//     Highlights standard Queen movement, plus adjacent friendlies for domination (cyan).
+// - applyDominationAbility(queen, targetPiece, allPieces):
+//     Stores the original piece inside QueenOfDomination and replaces the target with a Queen sprite.
+// - returnOriginalSprite(dominatingQueen, movedPiece, allPieces):
+//     After movement, restores the dominated piece to its original type at the new location.
+
+import { getPieceAt } from '~/pixi/utils';
+import { highlightMoves as highlightQueenMoves } from '~/pixi/pieces/basic/Queen';
+import { setIsInDominationMode } from '~/state/gameState';
+
+/**
+ * Highlights valid QueenOfDomination movement.
+ * Also highlights adjacent friendly pieces in cyan if domination ability is still available.
+ *
+ * @param {Object} queen - The QueenOfDomination piece.
+ * @param {Function} addHighlight - Callback to register highlights.
+ * @param {Array} allPieces - Current list of all active board pieces.
+ */
+export function highlightMoves(queen, addHighlight, allPieces) {
+  highlightQueenMoves(queen, addHighlight, allPieces);
+
+  // Highlight adjacent friendly units if domination ability is unused
+  if (!queen.pieceLoaded) {
+    const offsets = [-1, 0, 1];
+    for (const deltaRow of offsets) {
+      for (const deltaCol of offsets) {
+        if (deltaRow === 0 && deltaCol === 0) continue;
+        const neighborRow = queen.row + deltaRow;
+        const neighborCol = queen.col + deltaCol;
+
+        if (neighborRow >= 0 && neighborRow < 8 && neighborCol >= 0 && neighborCol < 8) {
+          const neighborPiece = getPieceAt({ row: neighborRow, col: neighborCol }, allPieces);
+          if (neighborPiece && neighborPiece.color === queen.color) {
+            addHighlight(neighborRow, neighborCol, 0x00ffff); // Cyan highlight for domination candidates
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Applies the domination ability to an adjacent friendly unit.
+ * Replaces the target with a Queen sprite and saves the original inside the QueenOfDomination.
+ *
+ * @param {Object} queen - The QueenOfDomination initiating the domination.
+ * @param {Object} targetPiece - The adjacent friendly unit being dominated.
+ * @param {Array} allPieces - Current full board state.
+ * @returns {Array} Updated list of pieces after domination.
+ */
+export function applyDominationAbility(queen, targetPiece, allPieces) {
+  setIsInDominationMode(true);
+  
+  if (queen.pieceLoaded) {
+    return allPieces; // Ability already used
+  }
+
+  const updatedQueen = { ...queen, pieceLoaded: { ...targetPiece } };
+
+  const transformedTarget = {
+    ...targetPiece,
+    type: 'Queen',
+    stunned: false,
+    raisesLeft: 0,
+    pieceLoaded: null,
+  };
+
+  return allPieces.map(piece => {
+    if (piece.id === queen.id) return updatedQueen;
+    if (piece.id === targetPiece.id) return transformedTarget;
+    return piece;
+  });
+}
+
+/**
+ * Reverts a dominated piece back to its original form after the move completes.
+ * Restores the original piece at the final destination of the dominated Queen.
+ *
+ * @param {Object} dominatingQueen - The QueenOfDomination that initiated domination.
+ * @param {Object} movedPiece - The moved dominated Queen (now at its final location).
+ * @param {Array} allPieces - Current full board state.
+ * @returns {Array} Updated list of pieces after reversion.
+ */
+export function returnOriginalSprite(dominatingQueen, movedPiece, allPieces) {
+  setIsInDominationMode(false);
+
+  if (!dominatingQueen.pieceLoaded) {
+    return allPieces; // Nothing to revert
+  }
+
+  const revivedPiece = {
+    ...dominatingQueen.pieceLoaded,
+    row: movedPiece.row,
+    col: movedPiece.col,
+    stunned: false,
+    raisesLeft: 0,
+    pieceLoaded: null,
+  };
+
+  const updatedPieces = allPieces
+    .filter(piece => piece.id !== dominatingQueen.pieceLoaded.id) // Remove the temporary Queen
+    .map(piece =>
+      piece.id === dominatingQueen.id
+        ? { ...dominatingQueen, pieceLoaded: null } // Clear the QueenOfDomination tracker
+        : piece
+    )
+    .concat(revivedPiece); // Restore the original piece
+
+  return updatedPieces;
+}

--- a/frontend/src/state/gameState.js
+++ b/frontend/src/state/gameState.js
@@ -1,17 +1,49 @@
 import { createSignal } from 'solid-js';
 
 export const [selectedSquare, setSelectedSquare] = createSignal(null);
-export const [highlights, setHighlights] = createSignal([]);
-export const [resurrectionTargets, setResurrectionTargets] = createSignal([]);
-export const [pendingResurrectionColor, setPendingResurrectionColor] = createSignal(null);
-export const [sacrificeMode, setSacrificeMode] = createSignal(null);
-export const [sacrificeArmed, setSacrificeArmed] = createSignal(false);
-export const [launchMode, setLaunchMode] = createSignal(null);
-export const [isInLoadingMode, setIsInLoadingMode] = createSignal(false);
-export const [isInSacrificeSelectionMode, setIsInSacrificeSelectionMode] = createSignal(false);
-export const [capturedPiece, setCapturedPiece] = createSignal(null);
-export const [isInBoulderMode, setIsInBoulderMode] = createSignal(false);
+// Currently selected square (row, col) where the player has clicked.
+// Used to track which piece is active for movement or ability use.
 
+export const [highlights, setHighlights] = createSignal([]);
+// List of tiles (row, col, color) that are currently highlighted on the board.
+// Used for showing valid moves, captures, ability targets, etc.
+
+export const [resurrectionTargets, setResurrectionTargets] = createSignal([]);
+// List of valid squares (row, col) where a piece can be resurrected.
+// Used by Necromancer and GhoulKing resurrection abilities.
+
+export const [pendingResurrectionColor, setPendingResurrectionColor] = createSignal(null);
+// Color ("White" or "Black") of the piece being resurrected.
+// Temporarily stored while selecting resurrection tiles.
+
+export const [sacrificeMode, setSacrificeMode] = createSignal(null);
+// Tracks whether a piece (like NecroPawn) is in the middle of preparing a sacrifice ability.
+// If non-null, clicking will trigger sacrifice behavior.
+
+export const [sacrificeArmed, setSacrificeArmed] = createSignal(false);
+// True when a NecroPawn has been clicked once to "arm" its sacrifice.
+// False when the player cancels or detonates.
+
+export const [launchMode, setLaunchMode] = createSignal(null);
+// Holds the piece (like DeadLauncher) that is ready to launch a projectile.
+// If non-null, the player can click a launch target.
+
+export const [isInLoadingMode, setIsInLoadingMode] = createSignal(false);
+// True if a piece (DeadLauncher) is currently trying to load a Pawn.
+// False if normal movement mode.
+
+export const [isInSacrificeSelectionMode, setIsInSacrificeSelectionMode] = createSignal(false);
+// Used to track if the player is choosing which NecroPawn to sacrifice after a special ability is triggered.
+
+export const [capturedPiece, setCapturedPiece] = createSignal(null);
+// Tracks the most recently captured piece during move handling.
+// Used for special effects triggered by captures (e.g., QueenOfBones resurrection check).
+
+export const [isInBoulderMode, setIsInBoulderMode] = createSignal(false);
+// True if BoulderThrower has toggled into launch/capture mode instead of movement mode.
+
+export const [isInDominationMode, setIsInDominationMode] = createSignal(false);
+// True if QueenOfDomination has activated its ability to dominate a piece.
 
 // Corrected standard chess layout
 export const [pieces, setPieces] = createSignal([
@@ -19,7 +51,7 @@ export const [pieces, setPieces] = createSignal([
   { id: 1, type: "BoulderThrower", color: "White", row: 0, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 2, type: "BeastKnight", color: "White", row: 0, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 3, type: "BeastDruid", color: "White", row: 0, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0 },
-  { id: 4, type: "Queen", color: "White", row: 0, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0 },
+  { id: 4, type: "QueenOfDomination", color: "White", row: 0, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null },
   { id: 5, type: "FrogKing", color: "White", row: 0, col: 4, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 6, type: "BeastDruid", color: "White", row: 0, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0 },
   { id: 7, type: "BeastKnight", color: "White", row: 0, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0 },


### PR DESCRIPTION
This pull request introduces the new `QueenOfDomination` piece, a specialized chess piece with unique abilities. The changes include adding the logic for its behavior, integrating it into the game state and board interactions, and ensuring compatibility with existing mechanics.

### New `QueenOfDomination` Implementation:

* **Core Logic and Abilities**:
  - Added `QueenOfDomination.js` to define the piece's behavior, including the ability to temporarily dominate adjacent friendly pieces and revert them after movement.
  - Implemented the `handleQueenOfDominationClick` function to manage click interactions for the piece, including selecting targets and applying domination logic.

* **Highlight and Movement Updates**:
  - Updated `highlightMoves` to support highlighting adjacent friendly units for domination.
  - Integrated `QueenOfDomination` into the `pieceLogicMap` for highlight logic in `highlight.js`. [[1]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR18) [[2]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR42)

### Game State Adjustments:

* Added `isInDominationMode` signal to track whether the `QueenOfDomination` ability is active.
* Updated `clearBoardState` to reset domination mode when clearing the board. [[1]](diffhunk://#diff-bc94409e0a30d2a38a305542d1683e7cea1bbb60dbd4cff6f16230f120984aaaR9) [[2]](diffhunk://#diff-bc94409e0a30d2a38a305542d1683e7cea1bbb60dbd4cff6f16230f120984aaaR24)

### Integration into Gameplay:

* **Click Handling**:
  - Modified `handleSquareClick` to enforce movement rules when the `QueenOfDomination` ability is active and to handle clicks on the piece. [[1]](diffhunk://#diff-d79f8a98779a0792fe7881e2b042056773b83c64199fc086b48f4434976a6682R56-R67) [[2]](diffhunk://#diff-d79f8a98779a0792fe7881e2b042056773b83c64199fc086b48f4434976a6682R93-R97)
  - Added the `handleQueenOfDominationClick` import to `clickHandler.js`.

* **Piece Movement**:
  - Adjusted `handlePieceMove` to revert dominated pieces to their original state after movement. [[1]](diffhunk://#diff-b00ae8f3cf2f2ba4e2009098a73ca1009d349b895779da310752844824f26c7cR16) [[2]](diffhunk://#diff-b00ae8f3cf2f2ba4e2009098a73ca1009d349b895779da310752844824f26c7cR62-R83)

### Additional Changes:

* Updated the initial game state to include a `QueenOfDomination` piece in the default layout.