### PR TITLE
Add Queen of Illusions piece

### DIFF
--- a/frontend/src/pixi/clickHandler.js
+++ b/frontend/src/pixi/clickHandler.js
@@ -19,6 +19,7 @@ import { handleGhoulKingClick } from "./logic/handleGhoulKingClick";
 import { handleBoulderThrowerClick } from './pieces/beasts/BoulderThrower';
 import { handleQueenOfDominationClick } from '~/pixi/logic/handleQueenOfDominationClick';
 import { handleYoungWizZapClick } from '~/pixi/pieces/wizards/youngWiz';
+import { handleQueenOfIllusionsSwap } from '~/pixi/pieces/wizards/QueenOfIllusions';
 
 
 /**
@@ -98,6 +99,11 @@ export async function handleSquareClick(rowIndex, columnIndex, pixiApp) {
 
   // 6. Handle QueenOfDomination click logic
   if (await handleQueenOfDominationClick(rowIndex, columnIndex, pixiApp)) {
+    return;
+  }
+
+  // 7. Handle QueenOfIllusions click logic
+  if (await handleQueenOfIllusionsSwap(rowIndex, columnIndex, pixiApp)) {
     return;
   }
 

--- a/frontend/src/pixi/highlight.js
+++ b/frontend/src/pixi/highlight.js
@@ -17,6 +17,7 @@ import * as BoulderThrower from '~/pixi/pieces/beasts/BoulderThrower';
 import * as FrogKing from '~/pixi/pieces/beasts/FrogKing';
 import * as QueenOfDomination from '~/pixi/pieces/beasts/QueenOfDomination';
 import * as YoungWiz from '~/pixi/pieces/wizards/YoungWiz';
+import * as QueenOfIllusions from '~/pixi/pieces/wizards/QueenOfIllusions';
 
 /**
  * Mapping of piece types to their associated highlight logic modules.
@@ -42,6 +43,7 @@ const pieceLogicMap = {
   FrogKing,
   QueenOfDomination,
   YoungWiz,
+  QueenOfIllusions,
 };
 
 /**

--- a/frontend/src/pixi/pieces/wizards/QueenOfIllusions.js
+++ b/frontend/src/pixi/pieces/wizards/QueenOfIllusions.js
@@ -1,0 +1,97 @@
+// Filename: QueenOfIllusions.js
+// Description: Logic module for the Queen of Illusions, a level 2 Queen from the Wizard race.
+//
+// Main Functions:
+// - highlightMoves(queenOfIllusions, addHighlight, allPieces):
+//     Highlights valid queen movement options (straight and diagonal).
+// - highlightSwapTargets(queenOfIllusions, addHighlight, allPieces):
+//     Highlights all friendly Pawns and YoungWiz pieces in cyan, which are eligible for swapping.
+// - handleQueenOfIllusionsSwap(row, col, pixiApp):
+//     Handles the swap logic between the Queen of Illusions and a selected friendly Pawn/YoungWiz.
+//
+// Special Features:
+// - The Queen of Illusions moves like a regular Queen (straight and diagonal).
+// - On the first click, highlights all valid moves and friendly Pawns/YoungWiz in cyan.
+// - On the second click on a friendly Pawn/YoungWiz, swaps their position with the Queen of Illusions.
+
+import { highlightMoves as highlightStandardQueenMoves } from '~/pixi/pieces/basic/Queen'; // Import standard queen highlighting logic
+import { getPieceAt } from '~/pixi/utils';
+import { drawBoard } from '../../drawBoard';
+import { handleSquareClick } from '../../clickHandler';
+import { pieces, selectedSquare, setSelectedSquare, setPieces, setHighlights } from '~/state/gameState';
+
+/**
+ * Highlights valid queen movement options and friendly pieces eligible for swap.
+ *
+ * @param {Object} queenOfIllusions - The Queen of Illusions piece.
+ * @param {Function} addHighlight - Callback to add highlight tiles.
+ * @param {Array} allPieces - All the pieces currently on the board.
+ */
+export function highlightMoves(queenOfIllusions, addHighlight, allPieces) {
+  // Highlight standard queen movement (straight and diagonal)
+  highlightStandardQueenMoves(queenOfIllusions, addHighlight, allPieces);
+
+  // Highlight friendly Pawns and YoungWiz pieces eligible for swap (cyan)
+  highlightSwapTargets(queenOfIllusions, addHighlight, allPieces);
+}
+
+/**
+ * Highlights friendly Pawns and YoungWiz pieces in cyan, indicating they are eligible for swapping.
+ *
+ * @param {Object} queenOfIllusions - The Queen of Illusions piece.
+ * @param {Function} addHighlight - Callback to add highlight tiles.
+ * @param {Array} allPieces - All the pieces currently on the board.
+ */
+export function highlightSwapTargets(queenOfIllusions, addHighlight, allPieces) {
+  // Find all friendly Pawns and YoungWiz pieces
+  const friendlyPieces = allPieces.filter(piece =>
+    (piece.color === queenOfIllusions.color) &&
+    (piece.type === 'Pawn' || piece.type === 'YoungWiz')
+  );
+
+  // Highlight these friendly pieces
+  friendlyPieces.forEach(piece => {
+    addHighlight(piece.row, piece.col, 0x00FFFF); // Cyan color for eligible swap targets
+  });
+}
+
+/**
+ * Handles the swap logic when a friendly Pawn or YoungWiz is clicked.
+ *
+ * @param {number} row - The row index of the clicked square.
+ * @param {number} col - The column index of the clicked square.
+ * @param {Object} pixiApp - The PixiJS application instance, used to render the board.
+ * @returns {boolean} Returns true if the swap was performed, false otherwise.
+ */
+export function handleQueenOfIllusionsSwap(row, col, pixiApp) {
+  const currentPieces = pieces();
+  const selectedPosition = selectedSquare();
+  const queenPiece = selectedPosition ? getPieceAt(selectedPosition, currentPieces) : null;
+  const clickedPiece = getPieceAt({ row, col }, currentPieces);
+
+  if (!queenPiece || queenPiece.type !== 'QueenOfIllusions') return false;
+
+  // Ensure the clicked piece is a friendly Pawn or YoungWiz
+  if (clickedPiece && (clickedPiece.type === 'Pawn' || clickedPiece.type === 'YoungWiz') && clickedPiece.color === queenPiece.color) {
+    // Swap the positions of the Queen of Illusions and the clicked piece
+    const tempRow = queenPiece.row;
+    const tempCol = queenPiece.col;
+    
+    // Move the clicked piece to the Queen's position
+    clickedPiece.row = tempRow;
+    clickedPiece.col = tempCol;
+
+    // Move the Queen to the clicked piece's position
+    queenPiece.row = row;
+    queenPiece.col = col;
+
+    // Update the board with the swapped positions
+    setPieces([...currentPieces]);
+    setSelectedSquare(null);
+    setHighlights([]);
+    drawBoard(pixiApp, handleSquareClick);
+    return true;
+  }
+
+  return false;
+}

--- a/frontend/src/state/gameState.js
+++ b/frontend/src/state/gameState.js
@@ -51,7 +51,7 @@ export const [pieces, setPieces] = createSignal([
   { id: 1, type: "BoulderThrower", color: "White", row: 0, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null },
   { id: 2, type: "BeastKnight", color: "White", row: 0, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null },
   { id: 3, type: "BeastDruid", color: "White", row: 0, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null },
-  { id: 4, type: "QueenOfDomination", color: "White", row: 0, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null },
+  { id: 4, type: "QueenOfIllusions", color: "White", row: 0, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null },
   { id: 5, type: "FrogKing", color: "White", row: 0, col: 4, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null },
   { id: 6, type: "BeastDruid", color: "White", row: 0, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null },
   { id: 7, type: "BeastKnight", color: "White", row: 0, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null },


### PR DESCRIPTION
This pull request introduces a new game piece, the "Queen of Illusions," to the Wizard race in the game. The changes include implementing its unique movement and swapping logic, updating the game state, and integrating the piece into existing game systems.

### New Feature: Queen of Illusions

* **Queen of Illusions logic module**: Added a new file, `QueenOfIllusions.js`, which implements the movement and swapping mechanics for the Queen of Illusions. This includes highlighting valid moves, highlighting eligible swap targets (friendly Pawns and YoungWiz pieces), and handling the swap logic.

### Game State Updates

* **Initial piece setup**: Replaced the "Queen of Domination" with the "Queen of Illusions" in the initial game state configuration in `gameState.js`.

### Integration with Existing Systems

* **Click handling**: Updated `clickHandler.js` to include logic for handling clicks on the Queen of Illusions, invoking its unique swapping behavior. [[1]](diffhunk://#diff-d79f8a98779a0792fe7881e2b042056773b83c64199fc086b48f4434976a6682R22) [[2]](diffhunk://#diff-d79f8a98779a0792fe7881e2b042056773b83c64199fc086b48f4434976a6682R105-R109)
* **Highlight logic**: Updated `highlight.js` to integrate the Queen of Illusions into the piece logic map, ensuring its moves and swap targets are highlighted correctly. [[1]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR20) [[2]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR46)