### PR TITLE
Add Prowler piece

### DIFF
--- a/frontend/src/pixi/clickHandler.js
+++ b/frontend/src/pixi/clickHandler.js
@@ -26,6 +26,7 @@ import { handleFamiliarClick } from './pieces/wizards/Familiar';
 import { handlePortalClick } from './pieces/wizards/Portal';
 import { handleHowlerCapture } from './pieces/demons/Howler';
 import { handleHellPawnCapture } from './pieces/demons/Hellpawn';
+import { handleProwlerCapture } from './pieces/demons/Prowler';
 
 /**
  * Handles all game board click interactions.
@@ -141,6 +142,12 @@ export async function handleSquareClick(rowIndex, columnIndex, pixiApp) {
   if (await handleHellPawnCapture(rowIndex, columnIndex, pixiApp)) {
     return;
   }
+
+  // 14. Handle Prowler click logic
+  if (await handleProwlerCapture(rowIndex, columnIndex, pixiApp)) {
+    return;
+  }
+
 
   // === 4. Move currently selected piece to highlighted square
   if (isClickedHighlighted && currentSelection) {

--- a/frontend/src/pixi/highlight.js
+++ b/frontend/src/pixi/highlight.js
@@ -24,6 +24,7 @@ import * as Familiar from '~/pixi/pieces/wizards/Familiar';
 import * as Portal from '~/pixi/pieces/wizards/Portal';
 import * as Howler from '~/pixi/pieces/demons/Howler';
 import * as HellPawn from '~/pixi/pieces/demons/HellPawn';
+import * as Prowler from '~/pixi/pieces/demons/Prowler';
 
 /**
  * Mapping of piece types to their associated highlight logic modules.
@@ -55,7 +56,8 @@ const pieceLogicMap = {
   Familiar,
   Portal,
   Howler,
-  HellPawn, 
+  HellPawn,
+  Prowler,
 };
 
 /**

--- a/frontend/src/pixi/pieces/demons/HellPawn.js
+++ b/frontend/src/pixi/pieces/demons/HellPawn.js
@@ -1,4 +1,4 @@
-// Description: Logic module for the HellPawn piece, a unique pawn from the Necromancer Guild.
+// Description: Logic module for the HellPawn piece, a unique level 2 pawn from the Demons Guild.
 //
 // Main Functions:
 // - highlightMoves(hellPawn, addHighlight, allPieces):

--- a/frontend/src/pixi/pieces/demons/Howler.js
+++ b/frontend/src/pixi/pieces/demons/Howler.js
@@ -1,4 +1,5 @@
-// Description: Logic module for the Howler piece, a custom level 2 piece with dynamic movement abilities based on captured pieces.
+// Description: Logic module for the Howler piece, a custom level 2 Demons guild piece 
+// with dynamic movement abilities based on captured pieces.
 //
 // Main Functions:
 // - highlightMoves(howler, addHighlight, allPieces):

--- a/frontend/src/pixi/pieces/demons/Prowler.js
+++ b/frontend/src/pixi/pieces/demons/Prowler.js
@@ -1,0 +1,104 @@
+// Description: Logic module for the Prowler piece, a level 2 Knight from the Demons Guild.
+//
+// Main Functions:
+// - highlightMoves(prowler, addHighlight, allPieces):
+//     Highlights valid movement options for the Prowler using standard Knight movement (L-shape).
+// - handleProwlerCapture(row, col, pixiApp):
+//     Handles the capture logic for the Prowler piece. When the Prowler captures an enemy piece, it 
+//     is required to move again. The second move can be any valid Knight move, including returning 
+//     to the original position. The second move is highlighted after a capture.
+//
+// Special Features or Notes:
+// - The Prowler moves like a standard Knight, with L-shaped movement (2 squares in one direction and 
+//   1 square perpendicular to it).
+// - When the Prowler captures an enemy piece, it performs a second move after the capture.
+// - The second move will not be allowed until the first move (after capture) is completed.
+//
+// Usage or Context:
+// - This file integrates with the PixiJS board renderer and click handler. Movement logic is based on the standard 
+//   Knight movement module, with special handling for the second move after a capture, implemented in 
+//   `handleProwlerCapture.js`. 
+
+import { highlightMoves as highlightStandardKnightMoves } from '~/pixi/pieces/basic/Knight';
+import { getPieceAt } from '~/pixi/utils';
+import { drawBoard } from '../../drawBoard';
+import { handleSquareClick } from '../../clickHandler';
+import {
+    pieces,
+    selectedSquare,
+    setSelectedSquare,
+    setPieces,
+    setHighlights,
+    isSecondMove,
+    setIsSecondMove,
+} from '~/state/gameState';
+import { handleCapture } from '../../logic/handleCapture';
+
+/**
+ * Highlights all valid moves for the Prowler piece.
+ * Inherits standard knight behavior with diagonal movement.
+ *
+ * @param {Object} hellPawn - The Prowler piece being selected.
+ * @param {Function} addHighlight - Callback used to push highlight tiles.
+ * @param {Array} allPieces - Current state of all pieces on the board.
+ */
+export function highlightMoves(prowler, addHighlight, allPieces) {
+  highlightStandardKnightMoves(prowler, addHighlight, allPieces);
+}
+
+/**
+ * Handles the logic when the Prowler attempts to capture an opponent piece.
+ * The Prowler captures an enemy piece and gains the movement ability from its base class.
+ * After a capture, the Prowler must move one more time (can move back to the original square).
+ *
+ * @param {number} row - The row index of the clicked square.
+ * @param {number} col - The column index of the clicked square.
+ * @param {Object} pixiApp - The PixiJS application instance, used to render the board.
+ * @returns {boolean} Returns true if a capture was performed, false otherwise.
+ */
+export async function handleProwlerCapture(row, col, pixiApp) {
+  const currentPieces = pieces();
+  const selectedPosition = selectedSquare();
+  const prowlerPiece = selectedPosition ? getPieceAt(selectedPosition, currentPieces) : null;
+  const targetPiece = getPieceAt({ row, col }, currentPieces);
+
+  // Ensure the selected piece is a Prowler and it's not clicking on itself
+  if (!prowlerPiece || prowlerPiece.type !== 'Prowler' || targetPiece === prowlerPiece) return false;
+
+  // Check if the Prowler is in the middle of a second move
+  if (isSecondMove()) {
+    setIsSecondMove(false);
+    return false;
+  }
+
+  // Check if the target piece is an enemy piece
+  if (targetPiece && targetPiece.color !== prowlerPiece.color) {
+      let updatedPieces = handleCapture(targetPiece, currentPieces);
+
+      // Move the Prowler to the captured piece's square
+      prowlerPiece.row = row;
+      prowlerPiece.col = col;
+
+      // Update the pieces with the new position for the Prowler
+      updatedPieces = updatedPieces.filter(piece => piece.id !== prowlerPiece.id);  // Remove old Prowler
+      updatedPieces.push(prowlerPiece);  // Add the updated Prowler at the new position
+
+      setPieces(updatedPieces);
+      setSelectedSquare({ row, col });
+      setHighlights([]);
+      setIsSecondMove(true);
+
+      // Now highlight the second move for the Prowler
+      const highlightList = [];
+      highlightStandardKnightMoves(prowlerPiece, (highlightRow, highlightCol, color) => {
+          highlightList.push({ row: highlightRow, col: highlightCol, color });
+      }, updatedPieces);
+
+      setHighlights(highlightList);
+      drawBoard(pixiApp, handleSquareClick);
+
+      return true;
+  }
+
+  return false;
+}

--- a/frontend/src/state/gameState.js
+++ b/frontend/src/state/gameState.js
@@ -45,13 +45,16 @@ export const [isInBoulderMode, setIsInBoulderMode] = createSignal(false);
 export const [isInDominationMode, setIsInDominationMode] = createSignal(false);
 // True if QueenOfDomination has activated its ability to dominate a piece.
 
+export const [isSecondMove, setIsSecondMove] = createSignal(false);
+// True if the Prowler has captured an enemy piece and is now moving again.
+
 // Corrected standard chess layout
 export const [pieces, setPieces] = createSignal([
   // White Pieces (top of the board)
   { id: 1, type: "Portal", color: "White", row: 0, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false, 
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false }, 
   },
-  { id: 2, type: "Familiar", color: "White", row: 0, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 2, type: "Prowler", color: "White", row: 0, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
   { id: 3, type: "Howler", color: "White", row: 0, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
@@ -66,7 +69,7 @@ export const [pieces, setPieces] = createSignal([
   { id: 6, type: "Howler", color: "White", row: 0, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 7, type: "Familiar", color: "White", row: 0, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 7, type: "Prowler", color: "White", row: 0, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
   { id: 8, type: "Portal", color: "White", row: 0, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,


### PR DESCRIPTION
This pull request introduces the new "Prowler" piece to the game, a level 2 Knight from the Demons Guild with unique mechanics, including a mandatory second move after capturing an enemy piece. The changes include integrating the Prowler into the game logic, updating the board state, and adding its movement and capture behavior.

### New Feature: Prowler Piece Integration

* Added a new logic module for the Prowler piece in `frontend/src/pixi/pieces/demons/Prowler.js`, including its movement (standard Knight L-shape) and unique capture mechanics (mandatory second move after a capture).
* Updated the game state in `frontend/src/state/gameState.js` to include the Prowler piece, replacing instances of the Familiar piece in the initial board setup. Added a signal `isSecondMove` to track the Prowler's second move state. [[1]](diffhunk://#diff-3a25ba3f5bd42c16ca7bf6a926d221b3df739b255353223fbfa6a40ba5668593R48-R57) [[2]](diffhunk://#diff-3a25ba3f5bd42c16ca7bf6a926d221b3df739b255353223fbfa6a40ba5668593L69-R72)

### Game Logic Enhancements

* Integrated the Prowler's click handling logic in `frontend/src/pixi/clickHandler.js` to manage its unique capture and second-move behavior. [[1]](diffhunk://#diff-d79f8a98779a0792fe7881e2b042056773b83c64199fc086b48f4434976a6682R29) [[2]](diffhunk://#diff-d79f8a98779a0792fe7881e2b042056773b83c64199fc086b48f4434976a6682R146-R151)
* Updated the highlight logic in `frontend/src/pixi/highlight.js` to include the Prowler in the `pieceLogicMap` for movement highlighting. [[1]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR27) [[2]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR60)

### Documentation Updates

* Revised descriptions for the HellPawn and Howler pieces to clarify their guild and level in their respective files. [[1]](diffhunk://#diff-d85f15862eb094649b1a594b0cf9c8e0165aa4d01f9809779ce9e6f27466f855L1-R1) [[2]](diffhunk://#diff-3b45d525776040268864340af8ef77cdcd0ae492ad45e3b912825cd0a3273d8aL1-R2)