### PR TITLE
Add Beholder piece

### DIFF
--- a/frontend/src/pixi/clickHandler.js
+++ b/frontend/src/pixi/clickHandler.js
@@ -27,6 +27,7 @@ import { handlePortalClick } from './pieces/wizards/Portal';
 import { handleHowlerCapture } from './pieces/demons/Howler';
 import { handleHellPawnCapture } from './pieces/demons/Hellpawn';
 import { handleProwlerCapture } from './pieces/demons/Prowler';
+import { handleBeholderClick } from './pieces/demons/Beholder';
 
 /**
  * Handles all game board click interactions.
@@ -145,6 +146,11 @@ export async function handleSquareClick(rowIndex, columnIndex, pixiApp) {
 
   // 14. Handle Prowler click logic
   if (await handleProwlerCapture(rowIndex, columnIndex, pixiApp)) {
+    return;
+  }
+
+  // 15. Handle Beholder click logic
+  if (await handleBeholderClick(rowIndex, columnIndex, pixiApp)) {
     return;
   }
 

--- a/frontend/src/pixi/highlight.js
+++ b/frontend/src/pixi/highlight.js
@@ -25,6 +25,7 @@ import * as Portal from '~/pixi/pieces/wizards/Portal';
 import * as Howler from '~/pixi/pieces/demons/Howler';
 import * as HellPawn from '~/pixi/pieces/demons/HellPawn';
 import * as Prowler from '~/pixi/pieces/demons/Prowler';
+import * as Beholder from '~/pixi/pieces/demons/Beholder';
 
 /**
  * Mapping of piece types to their associated highlight logic modules.
@@ -58,6 +59,7 @@ const pieceLogicMap = {
   Howler,
   HellPawn,
   Prowler,
+  Beholder,
 };
 
 /**

--- a/frontend/src/pixi/logic/handleCapture.js
+++ b/frontend/src/pixi/logic/handleCapture.js
@@ -1,5 +1,4 @@
 import { triggerResurrectionPrompt } from '~/pixi/logic/handleResurrectionClick';
-import { setHighlights } from '../../state/gameState';
 
 /**
  * Handles removal of a captured piece and triggers post-capture logic (e.g. QueenOfBones revive).

--- a/frontend/src/pixi/pieces/beasts/BoulderThrower.js
+++ b/frontend/src/pixi/pieces/beasts/BoulderThrower.js
@@ -92,7 +92,6 @@ export function highlightCaptureZones(boulderThrower, addHighlight, allPieces) {
  */
 export async function handleBoulderThrowerClick(row, col, pixiApp) {
   const currentPieces = pieces();
-  const clickedPiece = getPieceAt({ row, col }, currentPieces);
   const currentSelection = selectedSquare();
   const selectedPiece = currentSelection ? getPieceAt(currentSelection, currentPieces) : null;
 
@@ -118,7 +117,8 @@ export async function handleBoulderThrowerClick(row, col, pixiApp) {
     selectedPiece &&
     selectedPiece.row === row &&
     selectedPiece.col === col &&
-    selectedPiece.type === 'BoulderThrower'
+    selectedPiece.type === 'BoulderThrower' &&
+    !isInBoulderMode()
   ) {
     const launchTargets = [];
     highlightCaptureZones(selectedPiece, (highlightRow, highlightCol, color) => {
@@ -132,23 +132,10 @@ export async function handleBoulderThrowerClick(row, col, pixiApp) {
     return true;
   }
 
-  // === Step 3: Initial selection of BoulderThrower
-  if (clickedPiece && clickedPiece.type === 'BoulderThrower') {
-    setIsInBoulderMode(false);
-    setSelectedSquare({ row, col });
-
-    const moveTargets = [];
-    highlightMoves(clickedPiece, (highlightRow, highlightCol, color) => {
-      moveTargets.push({ row: highlightRow, col: highlightCol, color });
-    }, currentPieces);
-
-    moveTargets.push({ row, col, color: 0x00ffff });
-    setHighlights(moveTargets);
-    await drawBoard(pixiApp, handleSquareClick);
-    return true;
-  }
-
   // === Step 4: Clicked elsewhere — deselect
-  setIsInBoulderMode(false);
+  if (selectedPiece && selectedPiece.type === 'BoulderThrower') {
+    setIsInBoulderMode(false);
+  }
+  
   return false;
 }

--- a/frontend/src/pixi/pieces/demons/Beholder.js
+++ b/frontend/src/pixi/pieces/demons/Beholder.js
@@ -1,0 +1,150 @@
+// Description: Implementation of the Beholder class, a level 2 piece from the Demon race in Battle Chess.
+// 
+// Main Classes:
+// - Beholder: Defines the behavior, movement, and capture rules for the Beholder piece on the chessboard. 
+//   The Beholder has the ability to move one step forward, backward, or sideways and can capture pieces by throwing boulders at them.
+//
+// Main Functions:
+// - highlightMoves(beholder, addHighlight, allPieces): Highlights all valid moves for the Beholder piece, which can move one square 
+//   forward, backward, or sideways. It avoids moving into occupied spaces unless capturing an opponent's piece.
+// - highlightCaptureZones(beholder, addHighlight, allPieces): Highlights all squares within a 3-tile Manhattan distance from the Beholder, 
+//   where it can throw a boulder and potentially capture an opponent's piece.
+// - handleBeholderClick(row, col, pixiApp): Handles the Beholder's capture logic when it is in Boulder mode (i.e., shooting enemies from disctance). 
+//   and toggles between movement and capture mode when clicked multiple times.
+//
+// Special Features or Notes:
+// - The Beholder moves one step at a time in any of the four cardinal directions: up, down, left, or right.
+// - The Beholder cannot move onto a square occupied by a friendly piece or enemy piece.
+// - It can shoot (a capture mechanic) within a 3-tile or 2-tile Manhattan distance, which does not require moving into the enemy piece's square.
+
+import { getPieceAt } from '~/pixi/utils';
+import { drawBoard } from '../../drawBoard';
+import { handleSquareClick } from '../../clickHandler';
+import {
+  pieces,
+  selectedSquare,
+  setSelectedSquare,
+  setPieces,
+  setHighlights,
+  isInBoulderMode,
+  setIsInBoulderMode,
+} from '~/state/gameState';
+import { handleCapture } from '../../logic/handleCapture';
+
+/**
+ * Adds highlight markers for all valid Beholder moves.
+ * The Beholder moves one step forward, backward, or sideways.
+ *
+ * @param {Object} beholder - The Beholder piece
+ * @param {Function} addHighlight - Callback to register highlight at (row, col, color)
+ * @param {Array} allPieces - List of all pieces currently on the board
+ */
+export function highlightMoves(beholder, addHighlight, allPieces) {
+  const { row, col, color } = beholder;
+
+  const directions = [
+    { rowOffset: -1, colOffset: 0 },  // up
+    { rowOffset: 1, colOffset: 0 },   // down
+    { rowOffset: 0, colOffset: -1 },  // left
+    { rowOffset: 0, colOffset: 1 },   // right
+  ];
+
+  for (const { rowOffset, colOffset } of directions) {
+    const targetRow = row + rowOffset;
+    const targetCol = col + colOffset;
+
+    // Check if the move is within bounds
+    if (targetRow < 0 || targetRow >= 8 || targetCol < 0 || targetCol >= 8) continue;
+
+    const targetPos = { row: targetRow, col: targetCol };
+    const targetPiece = getPieceAt(targetPos, allPieces);
+
+    if (!targetPiece) {
+      addHighlight(targetRow, targetCol, 0xffff00); // yellow for valid move
+    }
+  }
+}
+
+/**
+ * Highlights tiles exactly 3 tiles away (Manhattan distance) where the Beholder can throw a boulder.
+ *
+ * @param {Object} beholder - The piece currently being evaluated.
+ * @param {Function} addHighlight - Function to collect highlight targets.
+ * @param {Array} allPieces - Current pieces on the board.
+ */
+export function highlightCaptureZones(beholder, addHighlight, allPieces) {
+  const { row: originRow, col: originCol } = beholder;
+  const offsets = [
+    [3, 0], [2, 1], [1, 2], [0, 3],
+    [-3, 0], [-2, -1], [-1, -2], [0, -3],
+    [-2, 1], [-1, 2], [1, -2], [2, -1],
+    [2, 0], [0, 2], [1, -1], [-1, 1],
+    [1, 1], [-1, -1], [0, -2], [-2, 0],
+  ];
+
+  for (const [deltaRow, deltaCol] of offsets) {
+    const targetRow = originRow + deltaRow;
+    const targetCol = originCol + deltaCol;
+    if (targetRow >= 0 && targetRow < 8 && targetCol >= 0 && targetCol < 8) {
+      addHighlight(targetRow, targetCol, 0xff0000);
+    }
+  }
+}
+
+/**
+ * Handles the logic when the Beholder attempts to capture an opponent piece.
+ * The Beholder captures an enemy piece and gains the movement ability from its base class.
+ * After a capture, the Beholder must move one more time (can move back to the original square).
+ *
+ * @param {number} row - The row index of the clicked square.
+ * @param {number} col - The column index of the clicked square.
+ * @param {Object} pixiApp - The PixiJS application instance, used to render the board.
+ * @returns {boolean} Returns true if a capture was performed, false otherwise.
+ */
+export async function handleBeholderClick(row, col, pixiApp) {
+  const currentPieces = pieces();
+  const targetPiece = getPieceAt({ row, col }, currentPieces);
+  const currentSelection = selectedSquare();
+  const selectedPiece = currentSelection ? getPieceAt(currentSelection, currentPieces) : null;
+
+  // === Step 1: Launch capture logic
+  if (selectedPiece && selectedPiece.type === 'Beholder' && isInBoulderMode()) {
+    if (targetPiece && targetPiece.color !== selectedPiece.color) {
+      const captured = getPieceAt({ row, col }, currentPieces);
+      const updatedPieces = handleCapture(captured, currentPieces, selectedPiece);
+      setPieces(updatedPieces);
+      setSelectedSquare(null);
+      setHighlights([]);
+      setIsInBoulderMode(false);
+      await drawBoard(pixiApp, handleSquareClick);
+      return true;
+    }
+  }
+
+  // === Step 2: Toggle launch mode on second click
+  if (
+    selectedPiece &&
+    selectedPiece.row === row &&
+    selectedPiece.col === col &&
+    selectedPiece.type === 'Beholder' &&
+    !isInBoulderMode()
+  ) {
+    const launchTargets = [];
+    highlightCaptureZones(selectedPiece, (highlightRow, highlightCol, color) => {
+      launchTargets.push({ row: highlightRow, col: highlightCol, color });
+    }, currentPieces);
+
+    launchTargets.push({ row, col, color: 0x00ffff });
+    setHighlights(launchTargets);
+    setIsInBoulderMode(true);
+    await drawBoard(pixiApp, handleSquareClick);
+    return true;
+  }
+
+  // === Step 4: Clicked elsewhere — deselect
+  if (selectedPiece && selectedPiece.type === 'Beholder') {
+    setIsInBoulderMode(false);
+  }
+
+  return false;
+}

--- a/frontend/src/pixi/pieces/demons/Prowler.js
+++ b/frontend/src/pixi/pieces/demons/Prowler.js
@@ -24,13 +24,13 @@ import { getPieceAt } from '~/pixi/utils';
 import { drawBoard } from '../../drawBoard';
 import { handleSquareClick } from '../../clickHandler';
 import {
-    pieces,
-    selectedSquare,
-    setSelectedSquare,
-    setPieces,
-    setHighlights,
-    isSecondMove,
-    setIsSecondMove,
+  pieces,
+  selectedSquare,
+  setSelectedSquare,
+  setPieces,
+  setHighlights,
+  isSecondMove,
+  setIsSecondMove,
 } from '~/state/gameState';
 import { handleCapture } from '../../logic/handleCapture';
 
@@ -73,31 +73,31 @@ export async function handleProwlerCapture(row, col, pixiApp) {
 
   // Check if the target piece is an enemy piece
   if (targetPiece && targetPiece.color !== prowlerPiece.color) {
-      let updatedPieces = handleCapture(targetPiece, currentPieces);
+    let updatedPieces = handleCapture(targetPiece, currentPieces);
 
-      // Move the Prowler to the captured piece's square
-      prowlerPiece.row = row;
-      prowlerPiece.col = col;
+    // Move the Prowler to the captured piece's square
+    prowlerPiece.row = row;
+    prowlerPiece.col = col;
 
-      // Update the pieces with the new position for the Prowler
-      updatedPieces = updatedPieces.filter(piece => piece.id !== prowlerPiece.id);  // Remove old Prowler
-      updatedPieces.push(prowlerPiece);  // Add the updated Prowler at the new position
+    // Update the pieces with the new position for the Prowler
+    updatedPieces = updatedPieces.filter(piece => piece.id !== prowlerPiece.id);  // Remove old Prowler
+    updatedPieces.push(prowlerPiece);  // Add the updated Prowler at the new position
 
-      setPieces(updatedPieces);
-      setSelectedSquare({ row, col });
-      setHighlights([]);
-      setIsSecondMove(true);
+    setPieces(updatedPieces);
+    setSelectedSquare({ row, col });
+    setHighlights([]);
+    setIsSecondMove(true);
 
-      // Now highlight the second move for the Prowler
-      const highlightList = [];
-      highlightStandardKnightMoves(prowlerPiece, (highlightRow, highlightCol, color) => {
-          highlightList.push({ row: highlightRow, col: highlightCol, color });
-      }, updatedPieces);
+    // Now highlight the second move for the Prowler
+    const highlightList = [];
+    highlightStandardKnightMoves(prowlerPiece, (highlightRow, highlightCol, color) => {
+        highlightList.push({ row: highlightRow, col: highlightCol, color });
+    }, updatedPieces);
 
-      setHighlights(highlightList);
-      drawBoard(pixiApp, handleSquareClick);
+    setHighlights(highlightList);
+    drawBoard(pixiApp, handleSquareClick);
 
-      return true;
+    return true;
   }
 
   return false;

--- a/frontend/src/state/gameState.js
+++ b/frontend/src/state/gameState.js
@@ -51,7 +51,7 @@ export const [isSecondMove, setIsSecondMove] = createSignal(false);
 // Corrected standard chess layout
 export const [pieces, setPieces] = createSignal([
   // White Pieces (top of the board)
-  { id: 1, type: "Portal", color: "White", row: 0, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false, 
+  { id: 1, type: "Beholder", color: "White", row: 0, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false, 
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false }, 
   },
   { id: 2, type: "Prowler", color: "White", row: 0, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
@@ -72,7 +72,7 @@ export const [pieces, setPieces] = createSignal([
   { id: 7, type: "Prowler", color: "White", row: 0, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 8, type: "Portal", color: "White", row: 0, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 8, type: "BoulderThrower", color: "White", row: 0, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
   { id: 9,  type: "HellPawn", color: "White", row: 1, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,


### PR DESCRIPTION
This pull request introduces the implementation of the new "Beholder" piece for the game, along with adjustments to the "BoulderThrower" piece's behavior. The changes include adding the Beholder's movement and capture logic, integrating it into the game state and highlight systems, and refining BoulderThrower's functionality for better gameplay consistency.

### Beholder Implementation:

* Added a new `Beholder` piece with unique movement and capture mechanics, including the ability to move one square in cardinal directions and capture pieces within a 3-tile Manhattan distance using a "boulder throw" mechanic. (`frontend/src/pixi/pieces/demons/Beholder.js`)
* Integrated `Beholder` into the click handling system by adding `handleBeholderClick` to manage its interactions and toggling between movement and capture modes. (`frontend/src/pixi/clickHandler.js`) [[1]](diffhunk://#diff-d79f8a98779a0792fe7881e2b042056773b83c64199fc086b48f4434976a6682R30) [[2]](diffhunk://#diff-d79f8a98779a0792fe7881e2b042056773b83c64199fc086b48f4434976a6682R152-R156)
* Updated the highlight logic to include the Beholder's movement and capture zones. (`frontend/src/pixi/highlight.js`) [[1]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR28) [[2]](diffhunk://#diff-96856cf9c8a15d5317855866edec395c04c5eaf79fde594b57b094488cca64edR62)
* Added the Beholder to the initial game state configuration. (`frontend/src/state/gameState.js`)

### BoulderThrower Adjustments:

* Refined the `BoulderThrower` piece's logic to prevent activation of "boulder mode" when it is already active and to improve deselection behavior. (`frontend/src/pixi/pieces/beasts/BoulderThrower.js`) [[1]](diffhunk://#diff-9d1e4dd940e63001c0d5ef03cc1786e17c6c3e3e12d015077002b2b0d7319b5bL95) [[2]](diffhunk://#diff-9d1e4dd940e63001c0d5ef03cc1786e17c6c3e3e12d015077002b2b0d7319b5bL121-R121) [[3]](diffhunk://#diff-9d1e4dd940e63001c0d5ef03cc1786e17c6c3e3e12d015077002b2b0d7319b5bL135-L152)
* Replaced an initial `Portal` piece with a `BoulderThrower` in the game state to reflect updated gameplay mechanics. (`frontend/src/state/gameState.js`)

### Code Cleanup:

* Removed an unused import (`setHighlights`) from the `handleCapture` logic file to streamline the code. (`frontend/src/pixi/logic/handleCapture.js`)