### PR TITLE
Add turn system

### DIFF
--- a/frontend/src/pixi/clickHandler.js
+++ b/frontend/src/pixi/clickHandler.js
@@ -165,7 +165,7 @@ export async function handleSquareClick(rowIndex, columnIndex, pixiApp) {
   if (isClickedHighlighted && currentSelection) {
     const moveSuccessful = await handlePieceMove(
       { row: rowIndex, col: columnIndex },
-      pixiApp
+      pixiApp,
     );
     if (moveSuccessful) return;
   }

--- a/frontend/src/pixi/clickHandler.js
+++ b/frontend/src/pixi/clickHandler.js
@@ -5,7 +5,11 @@ import {
   highlights,
   setHighlights,
   isInDominationMode,
+  currentTurn,
+  switchTurn,
 } from '~/state/gameState';
+
+import { getPieceAt } from './utils';
 
 import { highlightValidMovesForPiece } from '~/pixi/highlight';
 import { isSquareSelected } from '~/pixi/utils';
@@ -59,11 +63,123 @@ export async function handleSquareClick(rowIndex, columnIndex, pixiApp) {
   const isClickedHighlighted = highlights().some(
     highlight =>
       highlight.row === rowIndex &&
-      highlight.col === columnIndex &&
-      !isReclickedSelection
+      highlight.col === columnIndex
   );
 
-  // === 0. Check if in the middle of domination move
+  // Move currently selected piece to highlighted square
+  if (isClickedHighlighted && currentSelection) {
+
+    let selectedPiece = getPieceAt(currentSelection, currentPieces);
+    if (!selectedPiece) {return;}
+    let isTurn = selectedPiece.color === currentTurn();
+
+    // 1. Check for NecroPawn sacrifice
+    if (
+      await handleSacrificeClick(rowIndex, columnIndex, pixiApp, currentPieces, isTurn)) {
+      return;
+    }
+
+    // 2. Handle special DeadLauncher behavior
+    if (await handleDeadLauncherClick(rowIndex, columnIndex, pixiApp, isTurn)) {
+      return;
+    }
+
+    // 3. Handle special GhoulKing behavior
+    if (await handleGhoulKingClick(rowIndex, columnIndex, pixiApp)) {
+      return;
+    }
+
+    // 4. Handle BoulderThrower click logic
+    if (await handleBoulderThrowerClick(rowIndex, columnIndex, pixiApp, isTurn)) {
+      return;
+    }
+
+    // 5. Handle YoungWiz post-move logic
+    if (await handleYoungWizZapClick(rowIndex, columnIndex, pixiApp)) {
+      return;
+    }
+
+    // 6. Handle WizardTower capture logic
+    if (await handleWizardTowerCapture(rowIndex, columnIndex, pixiApp)) {
+      return;
+    }
+
+    // 7. Handle WizardKing logic
+    if (await handleWizardKingCapture(rowIndex, columnIndex, pixiApp, isTurn)) {
+      return;
+    }
+
+    // 8. Handle QueenOfDomination click logic
+    if (await handleQueenOfDominationClick(rowIndex, columnIndex, pixiApp)) {
+      return;
+    }
+
+    // 9. Handle QueenOfIllusions click logic
+    if (await handleQueenOfIllusionsSwap(rowIndex, columnIndex, pixiApp)) {
+      return;
+    }
+
+    // 10. Handle Familiar click logic
+    if (await handleFamiliarClick(rowIndex, columnIndex, pixiApp, isTurn)) {
+      return;
+    }
+
+    // 11. Handle Portal click logic
+    if (await handlePortalClick(rowIndex, columnIndex, pixiApp, isTurn)) {
+      return;
+    }
+
+    // 12. Handle Howler click logic
+    if (await handleHowlerCapture(rowIndex, columnIndex, pixiApp)) {
+      return;
+    }
+
+    // 13. Handle HellPawn click logic
+    if (await handleHellPawnCapture(rowIndex, columnIndex, pixiApp)) {
+      return;
+    }
+
+    // 14. Handle Prowler click logic
+    if (await handleProwlerCapture(rowIndex, columnIndex, pixiApp, isTurn)) {
+      return;
+    }
+
+    // 15. Handle Beholder click logic
+    if (await handleBeholderClick(rowIndex, columnIndex, pixiApp, isTurn)) {
+      return;
+    }
+
+    // 16. Handle HellKing click logic
+    if (await handleHellKingCapture(rowIndex, columnIndex, pixiApp, isTurn)) {
+      return;
+    }
+
+    if (isReclickedSelection) {
+      // If the clicked square is the same as the selected square, deselect it
+      await clearBoardState();
+      return;
+    }
+
+    // Check if the selected piece is of the correct player's color (turn check)
+    if (!isTurn) {
+      console.log("It's not your turn, you cannot move this piece.");
+      return false;
+    }
+
+    // Now attempt the move (only if it's the correct player's turn)
+    const moveSuccessful = await handlePieceMove(
+      { row: rowIndex, col: columnIndex },
+      pixiApp,
+    );
+
+    // Switch turn after the move if successful
+    if (moveSuccessful) {
+      switchTurn();
+      return;
+    }
+  }
+
+  // Check if in the middle of domination move
   if (isInDominationMode()) {
     const isClickedHighlighted = highlights().some(
       highlight => highlight.row === rowIndex && highlight.col === columnIndex
@@ -75,99 +191,10 @@ export async function handleSquareClick(rowIndex, columnIndex, pixiApp) {
     }
   }
 
-  // === 1. Check for NecroPawn sacrifice
-  if (await handleSacrificeClick(rowIndex, columnIndex, pixiApp, currentPieces)) {
+  // Handle resurrection tile placement
+  if (
+    await handleResurrectionClick(rowIndex, columnIndex, pixiApp)) {
     return;
-  }
-
-  // === 2. Handle resurrection tile placement
-  if (await handleResurrectionClick(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // === 3. Handle special DeadLauncher behavior
-  if (await handleDeadLauncherClick(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // 3. Handle special GhoulKing behavior
-  if (await handleGhoulKingClick(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // 4. Handle BoulderThrower click logic
-  if (await handleBoulderThrowerClick(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // 5. Handle YoungWiz post-move logic
-  if (await handleYoungWizZapClick(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // 6. Handle WizardTower capture logic
-  if (await handleWizardTowerCapture(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // 7. Handle WizardKing logic
-  if (await handleWizardKingCapture(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // 8. Handle QueenOfDomination click logic
-  if (await handleQueenOfDominationClick(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // 9. Handle QueenOfIllusions click logic
-  if (await handleQueenOfIllusionsSwap(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // 10. Handle Familiar click logic
-  if (await handleFamiliarClick(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // 11. Handle Portal click logic
-  if (await handlePortalClick(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // 12. Handle Howler click logic
-  if (await handleHowlerCapture(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // 13. Handle HellPawn click logic
-  if (await handleHellPawnCapture(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // 14. Handle Prowler click logic
-  if (await handleProwlerCapture(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // 15. Handle Beholder click logic
-  if (await handleBeholderClick(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-  // 16. Handle HellKing click logic
-  if (await handleHellKingCapture(rowIndex, columnIndex, pixiApp)) {
-    return;
-  }
-
-
-  // === 4. Move currently selected piece to highlighted square
-  if (isClickedHighlighted && currentSelection) {
-    const moveSuccessful = await handlePieceMove(
-      { row: rowIndex, col: columnIndex },
-      pixiApp,
-    );
-    if (moveSuccessful) return;
   }
 
   // === 5. Select a new piece

--- a/frontend/src/pixi/logic/clearBoardState.js
+++ b/frontend/src/pixi/logic/clearBoardState.js
@@ -7,8 +7,9 @@ import {
 	setSacrificeArmed,
 	setLaunchMode,
 	setIsInDominationMode,
+	setIsInBoulderMode,
+	setIsInLoadingMode,
 } from '~/state/gameState';
-import { setIsInLoadingMode } from '../../state/gameState';
 
 /**
  * Clears all board UI state and redraws.
@@ -22,6 +23,7 @@ export async function clearBoardState({ preserveLaunch = false } = {}) {
 	setSacrificeArmed(false);
 	setIsInLoadingMode(false);
 	setIsInDominationMode(false);
+	setIsInBoulderMode(false);
 
 	if (!preserveLaunch) {
 		setLaunchMode(null);

--- a/frontend/src/pixi/logic/handleCapture.js
+++ b/frontend/src/pixi/logic/handleCapture.js
@@ -15,13 +15,19 @@ export function handleCapture(capturedPiece, currentPieces, capturingPiece = nul
   // Check if the captured piece is turned to stone
   if (capturedPiece.isStone) {
     console.log(`${capturedPiece.type} is turned to stone and cannot be captured.`);
-    return currentPieces; // Do not capture the piece
+    return currentPieces;
   }
 
   // Triggger detonation effect if applicable
   const filteredPieces = triggerDetonate(capturedPiece.row, capturedPiece.col, currentPieces);
 
-  const updatedPieces = filteredPieces.filter(p => p.id !== capturedPiece.id);
+  // Remove the captured piece from the board
+  let updatedPieces = filteredPieces.filter(p => p.id !== capturedPiece.id);
+
+  // If capturing piece is a QueenOfDestruction, remove capturing piece from the board
+  if (capturingPiece && capturedPiece.type === 'QueenOfDestruction') {
+    updatedPieces = updatedPieces.filter(p => p.id !== capturingPiece.id);
+  }
 
   // Trigger resurrection effect if applicable
   triggerResurrectionPrompt(capturingPiece, capturedPiece, { row: capturedPiece.row, col: capturedPiece.col }, updatedPieces);

--- a/frontend/src/pixi/logic/handleDeadLauncherClick.js
+++ b/frontend/src/pixi/logic/handleDeadLauncherClick.js
@@ -17,7 +17,6 @@ import { handleSquareClick } from '../clickHandler';
 import { clearBoardState } from './clearBoardState';
 import { handleCapture } from '~/pixi/logic/handleCapture';
 
-
 /**
  * Handles DeadLauncher-specific interactions:
  * - Step 1: Select DeadLauncher normally (handled outside)
@@ -26,7 +25,7 @@ import { handleCapture } from '~/pixi/logic/handleCapture';
  * - Step 4: Click DeadLauncher again to enter launch mode
  * - Step 5: Click red-highlighted target to launch
  */
-export async function handleDeadLauncherClick(rowIndex, columnIndex, pixiApp) {
+export async function handleDeadLauncherClick(rowIndex, columnIndex, pixiApp, isTurn) {
   const allPieces = pieces();
   const clickedPiece = getPieceAt({ row: rowIndex, col: columnIndex }, allPieces);
   const selectedPosition = selectedSquare();
@@ -42,7 +41,7 @@ export async function handleDeadLauncherClick(rowIndex, columnIndex, pixiApp) {
       const selectedLauncher = getPieceAt(selectedPosition, allPieces);
       selectedLauncher.pawnLoaded = false;
       const captured = getPieceAt({ row: rowIndex, col: columnIndex }, allPieces);
-      const updatedPieces = handleCapture(captured, allPieces, selectedLauncher);
+      const updatedPieces = handleCapture(captured, allPieces);
       setPieces(updatedPieces);
       setLaunchMode(null);
       setSelectedSquare(null);
@@ -111,8 +110,9 @@ export async function handleDeadLauncherClick(rowIndex, columnIndex, pixiApp) {
 
     if (
       isTargetAdjacent &&
-      ["Pawn", "NecroPawn"].includes(clickedTargetPiece?.type) &&
-      clickedTargetPiece.color === launcherPiece.color
+      ["Pawn", "NecroPawn", "YoungWiz", "PawnHopper", "HellPawn"].includes(clickedTargetPiece?.type) &&
+      clickedTargetPiece.color === launcherPiece.color &&
+      isTurn
     ) {
       const updatedLauncher = { ...launcherPiece, pawnLoaded: true };
       setIsInLoadingMode(false);

--- a/frontend/src/pixi/logic/handlePieceMove.js
+++ b/frontend/src/pixi/logic/handlePieceMove.js
@@ -15,7 +15,6 @@ import { applyStunEffect } from '~/pixi/pieces/necro/GhostKnight';
 import { handlePawnHopperPostMove } from '~/pixi/pieces/beasts/PawnHopper';
 import { returnOriginalSprite } from '~/pixi/pieces/beasts/QueenOfDomination';
 import { handleCapture } from '~/pixi/logic/handleCapture';
-import { clearBoardState } from './clearBoardState';
 
 /**
  * Handles the movement of the currently selected piece to a destination square.

--- a/frontend/src/pixi/logic/handlePieceMove.js
+++ b/frontend/src/pixi/logic/handlePieceMove.js
@@ -44,18 +44,18 @@ export async function handlePieceMove(destination, pixiApp) {
   // Step 2: Handle capture if an enemy piece is at the destination
   if (targetPiece) {
     // If there is a piece at the destination, attempt to handle the capture
-    updatedPieces = handleCapture(targetPiece, allPieces); // Handle the capture (removes the captured piece)
+    updatedPieces = handleCapture(targetPiece, allPieces, selectedPiece);
     
     // If handleCapture fails (i.e., if no piece is captured), we should return early
     if (updatedPieces === allPieces) {
-      return; // Exit early if the capture failed
+      return;
     }
   }
 
   // Step 3: If the capture was successful, move the selected piece to the destination
   updatedPieces = updatedPieces.map(piece =>
-    piece.row === fromSquare.row && piece.col === fromSquare.col // Find the selected piece
-      ? { ...piece, row: destination.row, col: destination.col } // Move it to the destination
+    piece.row === fromSquare.row && piece.col === fromSquare.col
+      ? { ...piece, row: destination.row, col: destination.col }
       : piece
   );
 
@@ -84,9 +84,9 @@ export async function handlePieceMove(destination, pixiApp) {
 
   // Step 6: Commit state updates
   setPieces(updatedPieces);
-  setSelectedSquare(null); // Deselect the piece
-  setHighlights([]); // Clear any highlights
-  setSacrificeMode(null); // Clear sacrifice mode
+  setSelectedSquare(null);
+  setHighlights([]);
+  setSacrificeMode(null);
 
   // Step 7: Apply any passive effects triggered by the move
   const movedPieceFinal = { ...selectedPiece, row: destination.row, col: destination.col };
@@ -95,6 +95,6 @@ export async function handlePieceMove(destination, pixiApp) {
 
   // Step 8: Redraw the board
   await drawBoard(pixiApp, handleSquareClick);
-  return true; // Indicate a successful move
+  return true;
 }
 

--- a/frontend/src/pixi/logic/handleQueenOfDominationClick.js
+++ b/frontend/src/pixi/logic/handleQueenOfDominationClick.js
@@ -4,6 +4,7 @@ import {
   setSelectedSquare,
   selectedSquare,
   setHighlights,
+  currentTurn,
 } from '~/state/gameState';
 
 import { getPieceAt } from '~/pixi/utils';
@@ -41,7 +42,7 @@ export async function handleQueenOfDominationClick(row, col, pixiApp) {
   }
 
   // === Step 3: Process adjacent friendly click
-  if (clickedPiece && clickedPiece.color === queenPiece.color) {
+  if (clickedPiece && clickedPiece.color === queenPiece.color && clickedPiece.color === currentTurn()) {
     
     // --- Cancel if clicking herself again
     if (clickedPiece.id === queenPiece.id) {

--- a/frontend/src/pixi/logic/handleSacrificeClick.js
+++ b/frontend/src/pixi/logic/handleSacrificeClick.js
@@ -13,19 +13,20 @@ import { performNecroPawnSacrifice } from '~/pixi/pieces/necro/NecroPawn';
 import { highlightValidMovesForPiece } from '~/pixi/highlight';
 import { drawBoard } from '~/pixi/drawBoard';
 import { handleSquareClick } from '~/pixi/clickHandler';
+import { clearBoardState } from './clearBoardState';
 
 /**
  * Handles all NecroPawn-specific clicks.
  * Covers both arming and detonating.
  * @returns {boolean} true if handled
  */
-export async function handleSacrificeClick(row, col, pixiApp, allPieces) {
+export async function handleSacrificeClick(row, col, pixiApp, allPieces, isTurn) {
   const detonation =
     sacrificeMode()?.row === row &&
     sacrificeMode()?.col === col &&
     sacrificeArmed();
 
-  if (detonation) {
+  if (detonation && isTurn) {
     const pawn = sacrificeMode();
     performNecroPawnSacrifice(pawn, allPieces);
 
@@ -34,6 +35,13 @@ export async function handleSacrificeClick(row, col, pixiApp, allPieces) {
     setSelectedSquare(null);
     await drawBoard(pixiApp, handleSquareClick);
     return true;
+  }
+
+  if (detonation && !isTurn) {
+    // If it's not the player's turn, do nothing
+    clearBoardState();
+    await drawBoard(pixiApp, handleSquareClick);
+    return false;
   }
 
   // Step into sacrifice mode if same NecroPawn clicked

--- a/frontend/src/pixi/pieces/basic/Bishop.js
+++ b/frontend/src/pixi/pieces/basic/Bishop.js
@@ -1,4 +1,5 @@
 import { getPieceAt, isOpponentPiece } from '~/pixi/utils';
+import { currentTurn } from '~/state/gameState';
 
 /**
  * Adds highlight markers for all valid Bishop moves.
@@ -10,6 +11,9 @@ import { getPieceAt, isOpponentPiece } from '~/pixi/utils';
  */
 export function highlightMoves(piece, addHighlight, allPieces) {
   const { row, col, color } = piece;
+
+  // Get current turn directly from the signal
+  const isOpponentTurn = color !== currentTurn();
 
   const directions = [
     { rowStep: -1, colStep: -1 },
@@ -30,10 +34,10 @@ export function highlightMoves(piece, addHighlight, allPieces) {
       const targetPiece = getPieceAt(targetPos, allPieces);
 
       if (!targetPiece) {
-        addHighlight(targetRow, targetCol, 0xffff00); // yellow for movement
+        addHighlight(targetRow, targetCol, isOpponentTurn ? 0xe5e4e2 : 0xffff00); // yellow for movement
       } else {
         if (isOpponentPiece(targetPos, color, allPieces)) {
-          addHighlight(targetRow, targetCol, 0xff0000); // red for capture
+          addHighlight(targetRow, targetCol, isOpponentTurn ? 0xe5e4e2 : 0xff0000); // red for capture
         }
         break; // stop in any case when hitting a piece
       }

--- a/frontend/src/pixi/pieces/basic/King.js
+++ b/frontend/src/pixi/pieces/basic/King.js
@@ -1,4 +1,5 @@
 import { getPieceAt, isOpponentPiece } from '~/pixi/utils';
+import { currentTurn } from '~/state/gameState';
 
 /**
  * Highlight valid King moves (1 square in any direction).
@@ -8,6 +9,9 @@ import { getPieceAt, isOpponentPiece } from '~/pixi/utils';
  */
 export function highlightMoves(piece, addHighlight, allPieces) {
   const { row, col, color } = piece;
+
+  // Get current turn directly from the signal
+  const isOpponentTurn = color !== currentTurn();
 
   // All 8 adjacent directions
   const directions = [
@@ -30,9 +34,9 @@ export function highlightMoves(piece, addHighlight, allPieces) {
       const pieceAtTarget = getPieceAt(target, allPieces);
 
       if (!pieceAtTarget) {
-        addHighlight(targetRow, targetCol, 0xffff00); // Move
+        addHighlight(targetRow, targetCol, isOpponentTurn ? 0xe5e4e2 : 0xffff00); // Move
       } else if (isOpponentPiece(target, color, allPieces)) {
-        addHighlight(targetRow, targetCol, 0xff0000); // Capture
+        addHighlight(targetRow, targetCol, isOpponentTurn ? 0xe5e4e2 : 0xff0000); // Capture
       }
     }
   }

--- a/frontend/src/pixi/pieces/basic/Knight.js
+++ b/frontend/src/pixi/pieces/basic/Knight.js
@@ -1,4 +1,5 @@
 import { getPieceAt, isOpponentPiece } from '~/pixi/utils';
+import { currentTurn } from '~/state/gameState';
 
 /**
  * Adds highlight markers for all valid Knight moves.
@@ -11,6 +12,9 @@ import { getPieceAt, isOpponentPiece } from '~/pixi/utils';
  */
 export function highlightMoves(piece, addHighlight, allPieces) {
   const { row, col, color } = piece;
+
+  // Get current turn directly from the signal
+  const isOpponentTurn = color !== currentTurn();
 
   const knightMoves = [
     { rowOffset: -2, colOffset: -1 },
@@ -33,9 +37,9 @@ export function highlightMoves(piece, addHighlight, allPieces) {
     const targetPiece = getPieceAt(targetPos, allPieces);
 
     if (!targetPiece) {
-      addHighlight(targetRow, targetCol, 0xffff00); // yellow for movement
+      addHighlight(targetRow, targetCol, isOpponentTurn ? 0xe5e4e2 : 0xffff00); // yellow for movement
     } else if (isOpponentPiece(targetPos, color, allPieces)) {
-      addHighlight(targetRow, targetCol, 0xff0000); // red for capture
+      addHighlight(targetRow, targetCol, isOpponentTurn ? 0xe5e4e2 : 0xff0000); // red for capture
     }
   }
 }

--- a/frontend/src/pixi/pieces/basic/Pawn.js
+++ b/frontend/src/pixi/pieces/basic/Pawn.js
@@ -1,4 +1,5 @@
 import { getPieceAt, isOpponentPiece } from '~/pixi/utils';
+import { currentTurn } from '~/state/gameState';
 
 /**
  * Highlight all valid moves for a Pawn.
@@ -11,15 +12,21 @@ export function highlightMoves(piece, addHighlight, allPieces) {
   const direction = color === 'White' ? 1 : -1;
   const startRow = color === 'White' ? 1 : 6;
 
+  // Get current turn directly from the signal
+  const isOpponentTurn = color !== currentTurn(); // Check if it's the opponent's turn
+
+  // Determine the highlight color based on the turn
+  const highlightColor = isOpponentTurn ? 0xe5e4e2 : 0xffff00;
+
   // One step forward
   const forward1 = { row: row + direction, col };
   if (!getPieceAt(forward1, allPieces)) {
-    addHighlight(forward1.row, forward1.col, 0xffff00);
+    addHighlight(forward1.row, forward1.col, highlightColor);
 
     // Two steps forward if at starting row
     const forward2 = { row: row + 2 * direction, col };
     if (row === startRow && !getPieceAt(forward2, allPieces)) {
-      addHighlight(forward2.row, forward2.col, 0xffff00);
+      addHighlight(forward2.row, forward2.col, highlightColor);
     }
   }
 
@@ -27,7 +34,7 @@ export function highlightMoves(piece, addHighlight, allPieces) {
   for (const dc of [-1, 1]) {
     const diag = { row: row + direction, col: col + dc };
     if (isOpponentPiece(diag, color, allPieces)) {
-      addHighlight(diag.row, diag.col, 0xff0000);
+      addHighlight(diag.row, diag.col, highlightColor);
     }
   }
 }

--- a/frontend/src/pixi/pieces/basic/Pawn.js
+++ b/frontend/src/pixi/pieces/basic/Pawn.js
@@ -34,7 +34,7 @@ export function highlightMoves(piece, addHighlight, allPieces) {
   for (const dc of [-1, 1]) {
     const diag = { row: row + direction, col: col + dc };
     if (isOpponentPiece(diag, color, allPieces)) {
-      addHighlight(diag.row, diag.col, highlightColor);
+      addHighlight(diag.row, diag.col, isOpponentTurn ? 0xe5e4e2 : 0xff0000);
     }
   }
 }

--- a/frontend/src/pixi/pieces/basic/Queen.js
+++ b/frontend/src/pixi/pieces/basic/Queen.js
@@ -1,16 +1,23 @@
 import { getPieceAt, isOpponentPiece } from '~/pixi/utils';
+import { currentTurn } from '~/state/gameState';
 
 /**
- * Adds highlight markers for all valid Queen moves.
+ * Highlights all valid moves for a piece based on the current turn.
  * The Queen can move any number of spaces in a straight line (horizontal, vertical, or diagonal),
  * stopping at obstacles or opponent pieces.
  *
- * @param {Object} piece - The Queen piece
+ * @param {Object} piece - The Queen piece being selected
  * @param {Function} addHighlight - Callback to register highlight at (row, col, color)
  * @param {Array} allPieces - List of all pieces currently on the board
  */
 export function highlightMoves(piece, addHighlight, allPieces) {
   const { row, col, color } = piece;
+  
+  // Get current turn directly from the signal
+  const isOpponentTurn = color !== currentTurn(); // Check if it's the opponent's turn
+
+  // Determine the highlight color based on the turn
+  const highlightColor = isOpponentTurn ? 0xe5e4e2 : 0xffff00; // grey for opponent, yellow for the current player
 
   const directions = [
     { rowOffset: -1, colOffset: 0 },   // up
@@ -35,12 +42,14 @@ export function highlightMoves(piece, addHighlight, allPieces) {
 
       if (targetPiece) {
         if (isOpponentPiece(targetPos, color, allPieces)) {
-          addHighlight(targetRow, targetCol, 0xff0000); // red for capture
+          // Highlight the capture squares (red for opponent pieces)
+          addHighlight(targetRow, targetCol, isOpponentTurn ? 0xe5e4e2 : 0xff0000); // grey for opponent's turn, red for valid capture
         }
         break; // stop path after hitting any piece
       }
 
-      addHighlight(targetRow, targetCol, 0xffff00); // yellow for valid move
+      // Highlight valid move squares (yellow for the current player's turn, grey for opponent's turn)
+      addHighlight(targetRow, targetCol, highlightColor);
     }
   }
 }

--- a/frontend/src/pixi/pieces/basic/Rook.js
+++ b/frontend/src/pixi/pieces/basic/Rook.js
@@ -1,4 +1,5 @@
 import { getPieceAt, isOpponentPiece } from '~/pixi/utils';
+import { currentTurn } from '~/state/gameState';
 
 /**
  * Adds highlight markers for all valid Rook moves.
@@ -10,6 +11,12 @@ import { getPieceAt, isOpponentPiece } from '~/pixi/utils';
  */
 export function highlightMoves(piece, addHighlight, allPieces) {
   const { row, col, color } = piece;
+
+  // Get current turn directly from the signal
+  const isOpponentTurn = color !== currentTurn(); // Check if it's the opponent's turn
+
+  // Determine the highlight color based on the turn
+  const highlightColor = isOpponentTurn ? 0xe5e4e2 : 0xffff00;
 
   const directions = [
     { rowOffset: -1, colOffset: 0 },  // up
@@ -30,12 +37,14 @@ export function highlightMoves(piece, addHighlight, allPieces) {
 
       if (targetPiece) {
         if (isOpponentPiece(targetPos, color, allPieces)) {
-          addHighlight(targetRow, targetCol, 0xff0000); // red for capture
+          // Highlight the capture squares (red for opponent pieces)
+          addHighlight(targetRow, targetCol, highlightColor); // grey for opponent's turn, red for valid capture
         }
-        break;
+        break; // stop path after hitting any piece
       }
 
-      addHighlight(targetRow, targetCol, 0xffff00); // yellow for valid move
+      // Highlight valid move squares (yellow for the current player's turn, grey for opponent's turn)
+      addHighlight(targetRow, targetCol, highlightColor);
     }
   }
 }

--- a/frontend/src/pixi/pieces/basic/Rook.js
+++ b/frontend/src/pixi/pieces/basic/Rook.js
@@ -38,7 +38,7 @@ export function highlightMoves(piece, addHighlight, allPieces) {
       if (targetPiece) {
         if (isOpponentPiece(targetPos, color, allPieces)) {
           // Highlight the capture squares (red for opponent pieces)
-          addHighlight(targetRow, targetCol, highlightColor); // grey for opponent's turn, red for valid capture
+          addHighlight(targetRow, targetCol, isOpponentTurn ? 0xe5e4e2 : 0xff0000); // grey for opponent's turn, red for valid capture
         }
         break; // stop path after hitting any piece
       }

--- a/frontend/src/pixi/pieces/beasts/BeastKnight.js
+++ b/frontend/src/pixi/pieces/beasts/BeastKnight.js
@@ -13,6 +13,7 @@
 // - Used by the PixiJS board renderer to determine valid tiles when a BeastKnight is selected.
 
 import { getPieceAt } from '~/pixi/utils';
+import { currentTurn } from '~/state/gameState';
 
 /**
  * Highlights all valid moves for the BeastKnight.
@@ -24,6 +25,9 @@ import { getPieceAt } from '~/pixi/utils';
  */
 export function highlightMoves(beastKnight, addHighlight, allPieces) {
   const { row, col, color } = beastKnight;
+
+  // Get current turn directly from the signal
+  const isOpponentTurn = color !== currentTurn();
 
   // All 8 possible BeastKnight L-shaped moves
   const moveOffsets = [
@@ -47,9 +51,9 @@ export function highlightMoves(beastKnight, addHighlight, allPieces) {
     const targetPiece = getPieceAt({ row: targetRow, col: targetCol }, allPieces);
 
     if (!targetPiece) {
-      addHighlight(targetRow, targetCol); // Standard move
+      addHighlight(targetRow, targetCol, isOpponentTurn ? 0xe5e4e2 : 0xffff00); // Standard move
     } else if (targetPiece.color !== color) {
-      addHighlight(targetRow, targetCol, 0xff0000); // Capture
+      addHighlight(targetRow, targetCol, isOpponentTurn ? 0xe5e4e2 : 0xff0000); // Capture
     }
   }
 }

--- a/frontend/src/pixi/pieces/beasts/BoulderThrower.js
+++ b/frontend/src/pixi/pieces/beasts/BoulderThrower.js
@@ -37,6 +37,10 @@ import { handleCapture } from '~/pixi/logic/handleCapture';
  */
 export function highlightMoves(boulderThrower, addHighlight, allPieces) {
   const { row: originRow, col: originCol } = boulderThrower;
+
+  // highlight self in cyan
+  addHighlight(row, col, 0x00ffff);
+
   const directions = [
     { deltaRow: 1, deltaCol: 0 },
     { deltaRow: -1, deltaCol: 0 },

--- a/frontend/src/pixi/pieces/beasts/FrogKing.js
+++ b/frontend/src/pixi/pieces/beasts/FrogKing.js
@@ -18,6 +18,7 @@
 
 import { getPieceAt } from '~/pixi/utils';
 import { highlightMoves as highlightKingMoves } from '~/pixi/pieces/basic/King';
+import { currentTurn } from '~/state/gameState';
 
 /**
  * Highlights all valid movement and capture tiles for the FrogKing.
@@ -28,32 +29,37 @@ import { highlightMoves as highlightKingMoves } from '~/pixi/pieces/basic/King';
  * @param {Array} allPieces - All current game pieces on the board.
  */
 export function highlightMoves(frogKing, addHighlight, allPieces) {
-    // Step 1: Normal King movement
-    highlightKingMoves(frogKing, addHighlight, allPieces);
-  
-    // Step 2: Add 2-tile orthogonal hops
-    const hopOffsets = [
-      { rowOffset: 2, colOffset: 0 },
-      { rowOffset: -2, colOffset: 0 },
-      { rowOffset: 0, colOffset: 2 },
-      { rowOffset: 0, colOffset: -2 }
-    ];
-  
-    for (const { rowOffset, colOffset } of hopOffsets) {
-      const targetRow = frogKing.row + rowOffset;
-      const targetCol = frogKing.col + colOffset;
-  
-      // Stay within bounds
-      if (targetRow < 0 || targetRow >= 8 || targetCol < 0 || targetCol >= 8) continue;
-  
-      const targetPiece = getPieceAt({ row: targetRow, col: targetCol }, allPieces);
-  
-      // Skip if occupied by a friendly piece
-      if (targetPiece && targetPiece.color === frogKing.color) continue;
-  
-      // Highlight enemy targets in red, empty squares default color
-      const color = targetPiece ? 0xff0000 : undefined;
-      addHighlight(targetRow, targetCol, color);
-    }
+  // Step 1: Normal King movement (highlight like a standard King)
+  highlightKingMoves(frogKing, addHighlight, allPieces);
+
+  // Get current turn directly from the signal
+  const isOpponentTurn = frogKing.color !== currentTurn();
+
+  // Step 2: Add 2-tile orthogonal hops (move two squares in any direction)
+  const hopOffsets = [
+    { rowOffset: 2, colOffset: 0 },
+    { rowOffset: -2, colOffset: 0 },
+    { rowOffset: 0, colOffset: 2 },
+    { rowOffset: 0, colOffset: -2 }
+  ];
+
+  for (const { rowOffset, colOffset } of hopOffsets) {
+    const targetRow = frogKing.row + rowOffset;
+    const targetCol = frogKing.col + colOffset;
+
+    // Stay within bounds
+    if (targetRow < 0 || targetRow >= 8 || targetCol < 0 || targetCol >= 8) continue;
+
+    const targetPiece = getPieceAt({ row: targetRow, col: targetCol }, allPieces);
+
+    // Skip if occupied by a friendly piece
+    if (targetPiece && targetPiece.color === frogKing.color) continue;
+
+    // Determine the color for highlighting:
+    // - Red if it is an enemy piece
+    // - Grey if it is the opponent's turn
+    const highlightColor = isOpponentTurn ? 0xd3d3d3 : (targetPiece ? 0xff0000 : 0xffff00);
+
+    addHighlight(targetRow, targetCol, highlightColor);
   }
-  
+}

--- a/frontend/src/pixi/pieces/beasts/pawnHopper.js
+++ b/frontend/src/pixi/pieces/beasts/pawnHopper.js
@@ -15,6 +15,7 @@
 
 import { highlightMoves as highlightStandardPawnMoves } from '~/pixi/pieces/basic/Pawn';
 import { getPieceAt } from '~/pixi/utils';
+import { currentTurn } from '~/state/gameState';
 
 /**
  * Highlights all valid moves for a PawnHopper piece.
@@ -33,13 +34,18 @@ export function highlightMoves(pawnHopper, addHighlight, allPieces) {
   // Inherit single-step and diagonal capture logic from standard Pawn
   highlightStandardPawnMoves(pawnHopper, addHighlight, allPieces);
 
+  // Get current turn directly from the signal
+  const isOpponentTurn = pawnHopper.color !== currentTurn();
+
   // Add highlight for 2-step forward movement (hop capture)
   const squareAhead = getPieceAt({ row: oneStepRow, col: column }, allPieces);
   const squareTwoAhead = getPieceAt({ row: twoStepRow, col: column }, allPieces);
 
   if (!squareTwoAhead) {
     const isHopCapture = squareAhead && squareAhead.color !== pawnHopper.color;
-    const highlightColor = isHopCapture ? 0xff0000 : undefined;
+    const highlightColor = isOpponentTurn 
+    ? (isHopCapture ? 0xe5e4e2 : 0xd3d3d3) // Grey if opponent's turn, otherwise yellow
+    : (isHopCapture ? 0xff0000 : 0xffff00);
     addHighlight(twoStepRow, column, highlightColor);
   }
 }

--- a/frontend/src/pixi/pieces/demons/Beholder.js
+++ b/frontend/src/pixi/pieces/demons/Beholder.js
@@ -28,6 +28,7 @@ import {
   setHighlights,
   isInBoulderMode,
   setIsInBoulderMode,
+  currentTurn,
 } from '~/state/gameState';
 import { handleCapture } from '../../logic/handleCapture';
 
@@ -41,6 +42,15 @@ import { handleCapture } from '../../logic/handleCapture';
  */
 export function highlightMoves(beholder, addHighlight, allPieces) {
   const { row, col, color } = beholder;
+  
+  // highlight self in cyan
+  addHighlight(row, col, 0x00ffff);
+
+  // Get current turn directly from the signal
+  const isOpponentTurn = color !== currentTurn(); // Check if it's the opponent's turn
+
+  // Determine the highlight color based on the turn
+  const highlightColor = isOpponentTurn ? 0xe5e4e2 : 0xffff00;
 
   const directions = [
     { rowOffset: -1, colOffset: 0 },  // up
@@ -60,7 +70,7 @@ export function highlightMoves(beholder, addHighlight, allPieces) {
     const targetPiece = getPieceAt(targetPos, allPieces);
 
     if (!targetPiece) {
-      addHighlight(targetRow, targetCol, 0xffff00); // yellow for valid move
+      addHighlight(targetRow, targetCol, highlightColor); // yellow for valid move
     }
   }
 }
@@ -129,12 +139,17 @@ export async function handleBeholderClick(row, col, pixiApp) {
     selectedPiece.type === 'Beholder' &&
     !isInBoulderMode()
   ) {
+    // Get current turn directly from the signal
+    const isOpponentTurn = selectedPiece.color !== currentTurn(); // Check if it's the opponent's turn
+
+    // Determine the highlight color based on the turn
+    const highlightColor = isOpponentTurn ? 0xe5e4e2 : 0xff0000;
+
     const launchTargets = [];
-    highlightCaptureZones(selectedPiece, (highlightRow, highlightCol, color) => {
-      launchTargets.push({ row: highlightRow, col: highlightCol, color });
+    highlightCaptureZones(selectedPiece, (highlightRow, highlightCol) => {
+      launchTargets.push({ row: highlightRow, col: highlightCol, color: highlightColor});
     }, currentPieces);
 
-    launchTargets.push({ row, col, color: 0x00ffff });
     setHighlights(launchTargets);
     setIsInBoulderMode(true);
     await drawBoard(pixiApp, handleSquareClick);

--- a/frontend/src/pixi/pieces/demons/HellKing.js
+++ b/frontend/src/pixi/pieces/demons/HellKing.js
@@ -8,8 +8,8 @@ import {
   setSelectedSquare,
   setPieces,
   setHighlights,
+  switchTurn,
 } from '~/state/gameState';
-import { handleCapture } from '../../logic/handleCapture';
 
 /**
  * Highlights all valid moves for the HellKing piece.
@@ -32,7 +32,7 @@ export function highlightMoves(hellKing, addHighlight, allPieces) {
  * @param {Object} pixiApp - The PixiJS application instance, used to render the board.
  * @returns {boolean} Returns true if a capture was performed, false otherwise.
  */
-export function handleHellKingCapture(row, col, pixiApp) {
+export function handleHellKingCapture(row, col, pixiApp, isTurn) {
   const currentPieces = pieces();
   const selectedPosition = selectedSquare();
   const hellKingPiece = selectedPosition ? getPieceAt(selectedPosition, currentPieces) : null;
@@ -42,8 +42,8 @@ export function handleHellKingCapture(row, col, pixiApp) {
   if (!hellKingPiece || hellKingPiece.type !== 'HellKing' || targetPiece === hellKingPiece) return false;
 
   // Check if the target piece is an enemy piece
-  if (targetPiece && targetPiece.color !== hellKingPiece.color) {
-    let updatedPieces = handleCapture(targetPiece, currentPieces); // Handle capture logic
+  if (targetPiece && targetPiece.color !== hellKingPiece.color && targetPiece.isStone !== true && isTurn) {
+    let updatedPieces = currentPieces.filter(p => p.id !== targetPiece.id);
 
     // Now, the HellKing transforms into the captured piece (keeping the color of HellKing)
     const transformedPiece = { ...targetPiece };
@@ -59,6 +59,8 @@ export function handleHellKingCapture(row, col, pixiApp) {
     setPieces(updatedPieces);
     setSelectedSquare(null);
     setHighlights([]);
+    switchTurn();
+
     drawBoard(pixiApp, handleSquareClick);
     return true;
     }

--- a/frontend/src/pixi/pieces/demons/HellPawn.js
+++ b/frontend/src/pixi/pieces/demons/HellPawn.js
@@ -31,6 +31,7 @@ import {
     setSelectedSquare,
     setPieces,
     setHighlights,
+    switchTurn,
 } from '~/state/gameState';
 import { handleCapture } from '../../logic/handleCapture';
 
@@ -65,8 +66,13 @@ export function handleHellPawnCapture(row, col, pixiApp) {
     if (!hellPawnPiece || hellPawnPiece.type !== 'HellPawn' || targetPiece === hellPawnPiece) return false;
 
     // Check if the target piece is an enemy piece and not a pawn
-    if (targetPiece && targetPiece.color !== hellPawnPiece.color && targetPiece.type !== 'Pawn') {
-        let updatedPieces = handleCapture(targetPiece, currentPieces); // Handle capture logic
+    if (
+        targetPiece &&
+        targetPiece.color !== hellPawnPiece.color &&
+        targetPiece.type !== 'Pawn' &&
+        targetPiece.isStone !== true
+    ) {
+        let updatedPieces = handleCapture(targetPiece, currentPieces, hellPawnPiece);
 
         // Now, the HellPawn transforms into the captured piece (keeping the color of HellPawn)
         const transformedPiece = { ...targetPiece };
@@ -84,6 +90,7 @@ export function handleHellPawnCapture(row, col, pixiApp) {
         setSelectedSquare(null);
         setHighlights([]);
         drawBoard(pixiApp, handleSquareClick);
+        switchTurn();
         
         return true;
     }

--- a/frontend/src/pixi/pieces/demons/Howler.js
+++ b/frontend/src/pixi/pieces/demons/Howler.js
@@ -91,7 +91,7 @@ export function handleHowlerCapture(row, col, pixiApp) {
   }
 
   // Check if the target piece is an enemy piece
-  if (targetPiece) {
+  if (targetPiece && targetPiece.color !== howlerPiece.color && targetPiece.isStone !== true) {
     let updatedPieces = handleCapture(targetPiece, currentPieces);
     howlerPiece.row = row;
     howlerPiece.col = col;

--- a/frontend/src/pixi/pieces/demons/QueenOfDestruction.js
+++ b/frontend/src/pixi/pieces/demons/QueenOfDestruction.js
@@ -18,6 +18,7 @@
 import { highlightMoves as highlightStandardQueenMoves } from '~/pixi/pieces/basic/Queen';
 import { getSurroundingTiles } from '~/pixi/pieces/necro/NecroPawn';
 import { getPieceAt } from '~/pixi/utils';
+import { handleCapture } from '~/pixi/logic/handleCapture';
 
 /**
  * Highlights valid queen movement options.
@@ -27,7 +28,6 @@ import { getPieceAt } from '~/pixi/utils';
  * @param {Array} allPieces - All the pieces currently on the board.
  */
 export function highlightMoves(queenOfDestruction, addHighlight, allPieces) {
-  // Highlight standard queen movement
   highlightStandardQueenMoves(queenOfDestruction, addHighlight, allPieces);
 }
 
@@ -49,9 +49,20 @@ export function triggerDetonate(row, col, currentPieces) {
     // Get surrounding tiles
     const surroundingTiles = getSurroundingTiles(row, col);
 
-    // Remove all pieces within the surrounding area
-    let updatedPieces = currentPieces.filter(piece => {
-        return !surroundingTiles.some(tile => tile.row === piece.row && tile.col === piece.col);
+    // Find the pieces to be removed (those within the surrounding area)
+    const piecesToRemove = currentPieces.filter(piece => {
+      return surroundingTiles.some(tile => tile.row === piece.row && tile.col === piece.col);
+    });
+
+    // Apply handleCapture to each piece that is within the surrounding area
+    let updatedPieces = currentPieces;
+    for (const piece of piecesToRemove) {
+      updatedPieces = handleCapture(piece, updatedPieces);
+    }
+
+    // Remove the pieces within the surrounding area
+    updatedPieces = updatedPieces.filter(piece => {
+      return !surroundingTiles.some(tile => tile.row === piece.row && tile.col === piece.col);
     });
 
     // Return the updated list of pieces (with the removed pieces)

--- a/frontend/src/pixi/pieces/necro/DeadLauncher.js
+++ b/frontend/src/pixi/pieces/necro/DeadLauncher.js
@@ -27,6 +27,11 @@ import { getAdjacentTiles } from '../../utils';
 export function highlightMoves(piece, addHighlight, allPieces) {
   const isInLaunchMode = launchMode()?.id === piece.id;
   const isPawnLoaded = piece.pawnLoaded === true;
+  const row = piece.row;
+	const col = piece.col;
+  
+  // highlight self in cyan
+  addHighlight(row, col, 0x00ffff);
 
   // Step 2: Loading mode - highlight adjacent squares in cyan
   if (isInLoadingMode() && !isPawnLoaded) {

--- a/frontend/src/pixi/pieces/necro/GhoulKing.js
+++ b/frontend/src/pixi/pieces/necro/GhoulKing.js
@@ -28,5 +28,13 @@ import { highlightMoves as highlightKingMoves } from '~/pixi/pieces/basic/King';
  * @param {Array} allPieces - All current board pieces.
  */
 export function highlightMoves(ghoulKing, addHighlight, allPieces) {
-    highlightKingMoves(ghoulKing, addHighlight, allPieces);
+  highlightKingMoves(ghoulKing, addHighlight, allPieces);
+
+  if (ghoulKing.raisesLeft > 0) {
+    const row = ghoulKing.row;
+    const col = ghoulKing.col;
+    
+    // highlight self in cyan
+    addHighlight(row, col, 0x00ffff);
+  }
 }

--- a/frontend/src/pixi/pieces/necro/Necromancer.js
+++ b/frontend/src/pixi/pieces/necro/Necromancer.js
@@ -18,7 +18,7 @@
 
 import { getPieceAt } from '~/pixi/utils';
 import { setResurrectionTargets, setPendingResurrectionColor } from '~/state/gameState';
-
+import { highlightMoves as highlightStandardBishopMoves } from '../basic/Bishop';
 
 /**
  * Highlights all valid diagonal movement and capture positions for the Necromancer.
@@ -30,32 +30,9 @@ import { setResurrectionTargets, setPendingResurrectionColor } from '~/state/gam
  * @param {Function} addHighlight - Callback to register a highlight square.
  * @param {Array} allPieces - Current list of active game pieces.
  */
-export function highlightMoves(piece, addHighlight, allPieces) {
-  const directions = [
-    { dx: 1, dy: 1 }, { dx: 1, dy: -1 },
-    { dx: -1, dy: 1 }, { dx: -1, dy: -1 }
-  ];
-
-  for (const { dx, dy } of directions) {
-    for (let i = 1; i < 8; i++) {
-      const row = piece.row + i * dy;
-      const col = piece.col + i * dx;
-      if (row < 0 || row >= 8 || col < 0 || col >= 8) break;
-
-      const target = { row, col };
-      const occupant = getPieceAt(target, allPieces);
-      const isOpponent = occupant && occupant.color !== piece.color;
-
-      if (!occupant) {
-        addHighlight(row, col, 0xffff00);
-      } else {
-        if (isOpponent) {
-          addHighlight(row, col, 0xff0000);
-        }
-        break; // Can't move past occupied space
-      }
-    }
-  }
+export function highlightMoves(necromancer, addHighlight, allPieces) {
+  // Highlight standard Bishop moves
+  highlightStandardBishopMoves(necromancer, addHighlight, allPieces);
 }
 
 /**

--- a/frontend/src/pixi/pieces/necro/QueenOfBones.js
+++ b/frontend/src/pixi/pieces/necro/QueenOfBones.js
@@ -27,55 +27,55 @@
 // - Sacrifice and respawn behavior is triggered from `triggerResurrectionPrompt()` in `handlePieceMove.js`.
 
 import {
-    setResurrectionTargets,
-    setPendingResurrectionColor,
-    setIsInSacrificeSelectionMode,
-  } from '~/state/gameState';
+  setResurrectionTargets,
+  setPendingResurrectionColor,
+  setIsInSacrificeSelectionMode,
+} from '~/state/gameState';
   
-  import { highlightMoves as highlightStandardQueenMoves } from '~/pixi/pieces/basic/Queen';
+import { highlightMoves as highlightStandardQueenMoves } from '~/pixi/pieces/basic/Queen';
   
-  /**
-   * Highlights valid movement and capture tiles for the QueenOfBones.
-   * Delegates to standard Queen movement logic.
-   *
-   * @param {Object} queenOfBones - The QueenOfBones piece.
-   * @param {Function} addHighlight - Callback to register highlight objects.
-   * @param {Array} allPieces - All pieces currently on the board.
-   */
-  export function highlightMoves(queenOfBones, addHighlight, allPieces) {
-    highlightStandardQueenMoves(queenOfBones, addHighlight, allPieces);
+/**
+ * Highlights valid movement and capture tiles for the QueenOfBones.
+ * Delegates to standard Queen movement logic.
+ *
+ * @param {Object} queenOfBones - The QueenOfBones piece.
+ * @param {Function} addHighlight - Callback to register highlight objects.
+ * @param {Array} allPieces - All pieces currently on the board.
+ */
+export function highlightMoves(queenOfBones, addHighlight, allPieces) {
+  highlightStandardQueenMoves(queenOfBones, addHighlight, allPieces);
+}
+
+/**
+ * Triggers revival prompt for QueenOfBones after it is captured.
+ * If 2 or more friendly pawns exist, highlights them for sacrifice.
+ *
+ * @param {Array} updatedPieces - All board pieces after the QueenOfBones has been captured.
+ * @param {string} queenColor - The color of the QueenOfBones that was captured.
+ */
+export function triggerQueenOfBonesRevival(updatedPieces, queenColor) {
+  const eligiblePawns = updatedPieces.filter(
+    piece =>
+      piece.color === queenColor &&
+      (
+        piece.type === 'Pawn' ||
+        piece.type === 'NecroPawn' ||
+        piece.type === 'HellPawn' ||
+        piece.type === 'YoungWiz' ||
+        piece.type === 'PawnHopper'
+      )
+  );
+
+  if (eligiblePawns.length >= 2) {
+    const sacrificeTiles = eligiblePawns.map(pawn => ({
+      row: pawn.row,
+      col: pawn.col,
+      color: 0x00ffff,
+    }));
+
+    setResurrectionTargets(sacrificeTiles);
+    setPendingResurrectionColor(queenColor);
+    setIsInSacrificeSelectionMode(true);
   }
-  
-  /**
-   * Triggers revival prompt for QueenOfBones after it is captured.
-   * If 2 or more friendly pawns exist, highlights them for sacrifice.
-   *
-   * @param {Array} updatedPieces - All board pieces after the QueenOfBones has been captured.
-   * @param {string} queenColor - The color of the QueenOfBones that was captured.
-   */
-  export function triggerQueenOfBonesRevival(updatedPieces, queenColor) {
-    const eligiblePawns = updatedPieces.filter(
-      piece =>
-        piece.color === queenColor &&
-        (
-          piece.type === 'Pawn' ||
-          piece.type === 'NecroPawn' ||
-          piece.type === 'HellPawn' ||
-          piece.type === 'YoungWiz' ||
-          piece.type === 'PawnHopper'
-        )
-    );
-  
-    if (eligiblePawns.length >= 2) {
-      const sacrificeTiles = eligiblePawns.map(pawn => ({
-        row: pawn.row,
-        col: pawn.col,
-        color: 0x880088, // Purple highlight for sacrifice prompt
-      }));
-  
-      setResurrectionTargets(sacrificeTiles);
-      setPendingResurrectionColor(queenColor);
-      setIsInSacrificeSelectionMode(true);
-    }
-  }
+}
   

--- a/frontend/src/pixi/pieces/wizards/Familiar.js
+++ b/frontend/src/pixi/pieces/wizards/Familiar.js
@@ -15,7 +15,7 @@ import { highlightMoves as highlightStandardKnightMoves } from '~/pixi/pieces/ba
 import { getPieceAt } from '~/pixi/utils';
 import { drawBoard } from '../../drawBoard';
 import { handleSquareClick } from '../../clickHandler';
-import { pieces, selectedSquare, setSelectedSquare, setPieces, setHighlights } from '~/state/gameState';
+import { pieces, selectedSquare, setSelectedSquare, setPieces, setHighlights, switchTurn } from '~/state/gameState';
 
 /**
  * Highlights all valid moves for the Familiar piece.
@@ -45,7 +45,7 @@ export function highlightMoves(familiar, addHighlight, allPieces) {
  * @param {Object} pixiApp - The PixiJS application instance.
  * @returns {boolean} Returns true if the Familiar's state was toggled (stone/unstone), false otherwise.
  */
-export function handleFamiliarClick(row, col, pixiApp) {
+export function handleFamiliarClick(row, col, pixiApp, isTurn) {
   const currentPieces = pieces();
   const selectedPosition = selectedSquare();
   const familiarPiece = selectedPosition ? getPieceAt(selectedPosition, currentPieces) : null;
@@ -58,24 +58,28 @@ export function handleFamiliarClick(row, col, pixiApp) {
 
   if (familiarPiece.row !== row || familiarPiece.col !== col) {
     familiarPiece.isStone = false; 
-    return false; // Clicked square does not match the Familiar's position
+    return false;
   }
 
   // If the Familiar is clicked while it's turned to stone, undo the transformation
   if (familiarPiece.isStone) {
-    familiarPiece.isStone = false; // Unstone the Familiar
-    setPieces([...currentPieces]); // Update the board with the new state
-    setSelectedSquare(null); // Deselect the Familiar
-    setHighlights([]); // Clear the highlights
-    drawBoard(pixiApp, handleSquareClick); // Redraw the board
-    return true; // Successfully unstoned
+    familiarPiece.isStone = false;
+    setPieces([...currentPieces]);
+    setSelectedSquare(null);
+    setHighlights([]);
+    drawBoard(pixiApp, handleSquareClick);
+    return true;
   }
 
   // If the Familiar is clicked while not turned to stone, turn it to stone
-  familiarPiece.isStone = true; // Turn to stone
-  setPieces([...currentPieces]); // Update the board with the new state
-  setSelectedSquare(null); // Deselect the Familiar
-  setHighlights([]); // Clear the highlights
-  drawBoard(pixiApp, handleSquareClick); // Redraw the board
-  return true; // Successfully turned to stone
+  if (isTurn) {
+    familiarPiece.isStone = true;
+    setPieces([...currentPieces]);
+    setSelectedSquare(null);
+    setHighlights([]);
+    switchTurn();
+    drawBoard(pixiApp, handleSquareClick);
+    return true;
+  }
+  return false;
 }

--- a/frontend/src/pixi/pieces/wizards/Portal.js
+++ b/frontend/src/pixi/pieces/wizards/Portal.js
@@ -43,8 +43,16 @@ import { clearBoardState } from '~/pixi/logic/clearBoardState';
 export function highlightMoves(portal, addHighlight, allPieces) {
   const isInEjectMode = launchMode()?.id === portal.id;
 
+  const row = portal.row;
+	const col = portal.col;
+  
+  if (!isInLoadingMode() && !isInEjectMode) {
+    addHighlight(row, col, 0x00ffff); // Highlight portal in cyan
+  }
+
   // Step 2: Loading mode
   if (isInLoadingMode() && !portal.pieceLoaded) {
+    addHighlight(row, col, 0xffff00);
     const adjacentTiles = getAdjacentTiles(portal);
     for (const tile of adjacentTiles) {
       addHighlight(tile.row, tile.col, 0x00ffff);
@@ -54,6 +62,7 @@ export function highlightMoves(portal, addHighlight, allPieces) {
 
   // Step 3: Eject mode
   if (isInEjectMode && portal.pieceLoaded) {
+    addHighlight(row, col, 0xffff00);
     const adjacentTiles = getAdjacentTiles(portal);
     for (const tile of adjacentTiles) {
       addHighlight(tile.row, tile.col, 0x00ffff);

--- a/frontend/src/pixi/pieces/wizards/Portal.js
+++ b/frontend/src/pixi/pieces/wizards/Portal.js
@@ -47,7 +47,7 @@ export function highlightMoves(portal, addHighlight, allPieces) {
 	const col = portal.col;
   
   if (!isInLoadingMode() && !isInEjectMode) {
-    addHighlight(row, col, 0x00ffff); // Highlight portal in cyan
+    addHighlight(row, col, 0x00ffff);
   }
 
   // Step 2: Loading mode
@@ -83,14 +83,14 @@ export function highlightMoves(portal, addHighlight, allPieces) {
  * @param {Object} columnIndex - Column of the clicked square.
  * @param {Object} pixiApp - PixiJS application instance.
  */
-export async function handlePortalClick(rowIndex, columnIndex, pixiApp) {
+export async function handlePortalClick(rowIndex, columnIndex, pixiApp, isTurn) {
   const allPieces = pieces();
   const clickedPiece = getPieceAt({ row: rowIndex, col: columnIndex }, allPieces);
   const selectedPosition = selectedSquare();
-  const loadedPortal = launchMode();  // Get the portal in launch mode (if any)
+  const loadedPortal = launchMode();
 
   // Step 5: Eject at valid target
-  if (loadedPortal) {
+  if (loadedPortal && isTurn) {
     const isSquareValid = getAdjacentTiles(loadedPortal);
     const isTargetUnoccupied = !getPieceAt({ row: rowIndex, col: columnIndex }, allPieces);
 
@@ -118,7 +118,7 @@ export async function handlePortalClick(rowIndex, columnIndex, pixiApp) {
       setHighlights([]);
       await drawBoard(pixiApp, handleSquareClick);
 
-      return true;  // Successfully ejected the piece
+      return true;
     } else {
       clearBoardState();
     }
@@ -172,7 +172,8 @@ export async function handlePortalClick(rowIndex, columnIndex, pixiApp) {
   if (
     selectedPosition &&
     !launchMode() &&
-    getPieceAt(selectedPosition, allPieces)?.type === "Portal"
+    getPieceAt(selectedPosition, allPieces)?.type === "Portal" &&
+    isTurn
   ) {
     const launcherPiece = getPieceAt(selectedPosition, allPieces);
     if (!launcherPiece || !isInLoadingMode()) return false;

--- a/frontend/src/pixi/pieces/wizards/WizardKing.js
+++ b/frontend/src/pixi/pieces/wizards/WizardKing.js
@@ -16,7 +16,7 @@ import { highlightMoves as highlightStandardKingMoves } from '~/pixi/pieces/basi
 import { getPieceAt } from '~/pixi/utils';
 import { drawBoard } from '../../drawBoard';
 import { handleSquareClick } from '../../clickHandler';
-import { pieces, selectedSquare, setSelectedSquare, setPieces, setHighlights } from '~/state/gameState';
+import { pieces, selectedSquare, currentTurn, setSelectedSquare, setPieces, setHighlights } from '~/state/gameState';
 import { handleCapture } from '../../logic/handleCapture';
 
 /**
@@ -47,6 +47,9 @@ function highlightVerticalCapture(wizardKing, addHighlight, allPieces) {
   const directionUp = -1; // Upward direction
   const directionDown = 1; // Downward direction
   const column = wizardKing.col;
+
+  // Get current turn directly from the signal
+  const isOpponentTurn = wizardKing.color !== currentTurn();
   
   // Check vertical line upwards
   let currentRow = wizardKing.row + directionUp;
@@ -54,7 +57,7 @@ function highlightVerticalCapture(wizardKing, addHighlight, allPieces) {
     const pieceAtPos = getPieceAt({ row: currentRow, col: column }, allPieces);
     if (pieceAtPos) {
       if (pieceAtPos.color !== wizardKing.color) {
-        addHighlight(currentRow, column, 0xff0000); // Highlight the first enemy piece in the column (upward)
+        addHighlight(currentRow, column, isOpponentTurn ? 0xe5e4e2 : 0xff0000); // Highlight the first enemy piece in the column (upward)
       }
       break; // Stop at the first piece (no shooting through pieces)
     }
@@ -67,7 +70,7 @@ function highlightVerticalCapture(wizardKing, addHighlight, allPieces) {
     const pieceAtPos = getPieceAt({ row: currentRow, col: column }, allPieces);
     if (pieceAtPos) {
       if (pieceAtPos.color !== wizardKing.color) {
-        addHighlight(currentRow, column, 0xff0000); // Highlight the first enemy piece in the column (downward)
+        addHighlight(currentRow, column, isOpponentTurn ? 0xe5e4e2 : 0xff0000); // Highlight the first enemy piece in the column (downward)
       }
       break; // Stop at the first piece (no shooting through pieces)
     }

--- a/frontend/src/pixi/pieces/wizards/YoungWiz.js
+++ b/frontend/src/pixi/pieces/wizards/YoungWiz.js
@@ -12,7 +12,7 @@ import { highlightMoves as highlightStandardPawnMoves } from '~/pixi/pieces/basi
 import { getPieceAt } from '~/pixi/utils';
 import { drawBoard } from '../../drawBoard';
 import { handleSquareClick } from '../../clickHandler';
-import { pieces, selectedSquare, setSelectedSquare, setPieces, setHighlights } from '~/state/gameState';
+import { pieces, selectedSquare, setSelectedSquare, setPieces, setHighlights, currentTurn } from '~/state/gameState';
 import { handleCapture } from '../../logic/handleCapture';
 
 /**
@@ -26,11 +26,14 @@ export function highlightMoves(youngWiz, addHighlight, allPieces) {
   const direction = youngWiz.color === 'White' ? 1 : -1;
   highlightStandardPawnMoves(youngWiz, addHighlight, allPieces);
 
+  // Get current turn directly from the signal
+  const isOpponentTurn = youngWiz.color !== currentTurn();
+
   const zapCapturePosition = { row: youngWiz.row + direction, col: youngWiz.col };
   const pieceAtZap = getPieceAt(zapCapturePosition, allPieces);
 
   if (pieceAtZap && pieceAtZap.color !== youngWiz.color) {
-    addHighlight(zapCapturePosition.row, zapCapturePosition.col, 0xff0000); // Highlight zap capture in red
+    addHighlight(zapCapturePosition.row, zapCapturePosition.col, isOpponentTurn ? 0xe5e4e2 : 0xff0000); // Highlight zap capture in red
   }
 }
 

--- a/frontend/src/state/gameState.js
+++ b/frontend/src/state/gameState.js
@@ -48,6 +48,8 @@ export const [isInDominationMode, setIsInDominationMode] = createSignal(false);
 export const [isSecondMove, setIsSecondMove] = createSignal(false);
 // True if the Prowler has captured an enemy piece and is now moving again.
 
+// The state for the currently selected piece
+export const [selectedPiece, setSelectedPiece] = createSignal(null);
 
 // The state for current turn (white or black)
 export const [currentTurn, setCurrentTurn] = createSignal("White");
@@ -55,7 +57,7 @@ export const [currentTurn, setCurrentTurn] = createSignal("White");
 // Corrected standard chess layout
 export const [pieces, setPieces] = createSignal([
   // White Pieces (top of the board)
-  { id: 1, type: "Portal", color: "White", row: 0, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false, 
+  { id: 1, type: "BoulderThrower", color: "White", row: 0, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false, 
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false }, 
   },
   { id: 2, type: "Familiar", color: "White", row: 0, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
@@ -64,7 +66,7 @@ export const [pieces, setPieces] = createSignal([
   { id: 3, type: "Howler", color: "White", row: 0, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 4, type: "QueenOfDomination", color: "White", row: 0, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 4, type: "QueenOfDestruction", color: "White", row: 0, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
    },
   { id: 5, type: "HellKing", color: "White", row: 0, col: 4, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
@@ -76,7 +78,7 @@ export const [pieces, setPieces] = createSignal([
   { id: 7, type: "Prowler", color: "White", row: 0, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 8, type: "BoulderThrower", color: "White", row: 0, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 8, type: "Beholder", color: "White", row: 0, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
   { id: 9,  type: "HellPawn", color: "White", row: 1, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
@@ -108,25 +110,25 @@ export const [pieces, setPieces] = createSignal([
   { id: 17, type: "Beholder", color: "Black", row: 7, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 18, type: "BeastKnight", color: "Black", row: 7, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 18, type: "GhostKnight", color: "Black", row: 7, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
   { id: 19, type: "BeastDruid", color: "Black", row: 7, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 20, type: "QueenOfDestruction", color: "Black", row: 7, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 20, type: "QueenOfBones", color: "Black", row: 7, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
   { id: 21, type: "WizardKing", color: "Black", row: 7, col: 4, pawnLoaded: false, stunned: false, raisesLeft: 1, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 22, type: "WizardTower", color: "Black", row: 7, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 22, type: "Necromancer", color: "Black", row: 7, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
   { id: 23, type: "Prowler", color: "Black", row: 7, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 24, type: "BoulderThrower", color: "Black", row: 7, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 24, type: "DeadLauncher", color: "Black", row: 7, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
   { id: 25, type: "Pawn", color: "Black", row: 6, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,

--- a/frontend/src/state/gameState.js
+++ b/frontend/src/state/gameState.js
@@ -48,19 +48,23 @@ export const [isInDominationMode, setIsInDominationMode] = createSignal(false);
 export const [isSecondMove, setIsSecondMove] = createSignal(false);
 // True if the Prowler has captured an enemy piece and is now moving again.
 
+
+// The state for current turn (white or black)
+export const [currentTurn, setCurrentTurn] = createSignal("White");
+
 // Corrected standard chess layout
 export const [pieces, setPieces] = createSignal([
   // White Pieces (top of the board)
-  { id: 1, type: "Beholder", color: "White", row: 0, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false, 
+  { id: 1, type: "Portal", color: "White", row: 0, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false, 
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false }, 
   },
-  { id: 2, type: "Prowler", color: "White", row: 0, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 2, type: "Familiar", color: "White", row: 0, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
   { id: 3, type: "Howler", color: "White", row: 0, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 4, type: "QueenOfDestruction", color: "White", row: 0, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 4, type: "QueenOfDomination", color: "White", row: 0, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
    },
   { id: 5, type: "HellKing", color: "White", row: 0, col: 4, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
@@ -84,7 +88,7 @@ export const [pieces, setPieces] = createSignal([
   { id: 11, type: "HellPawn", color: "White", row: 1, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 12, type: "HellPawn", color: "White", row: 1, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 12, type: "PawnHopper", color: "White", row: 1, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
   { id: 13, type: "HellPawn", color: "White", row: 1, col: 4, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
@@ -93,7 +97,7 @@ export const [pieces, setPieces] = createSignal([
   { id: 14, type: "HellPawn", color: "White", row: 1, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 15, type: "HellPawn", color: "White", row: 1, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 15, type: "Pawn", color: "White", row: 1, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
   { id: 16, type: "HellPawn", color: "White", row: 1, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
@@ -101,37 +105,37 @@ export const [pieces, setPieces] = createSignal([
   },
 
   // Black Pieces (bottom of the board)
-  { id: 17, type: "DeadLauncher", color: "Black", row: 7, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 17, type: "Beholder", color: "Black", row: 7, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 18, type: "GhostKnight", color: "Black", row: 7, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 18, type: "BeastKnight", color: "Black", row: 7, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 19, type: "Necromancer", color: "Black", row: 7, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 19, type: "BeastDruid", color: "Black", row: 7, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 20, type: "QueenOfBones", color: "Black", row: 7, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 20, type: "QueenOfDestruction", color: "Black", row: 7, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 21, type: "GhoulKing", color: "Black", row: 7, col: 4, pawnLoaded: false, stunned: false, raisesLeft: 1, pieceLoaded: null, isStone: false,
+  { id: 21, type: "WizardKing", color: "Black", row: 7, col: 4, pawnLoaded: false, stunned: false, raisesLeft: 1, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 22, type: "Necromancer", color: "Black", row: 7, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 22, type: "WizardTower", color: "Black", row: 7, col: 5, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 23, type: "Knight", color: "Black", row: 7, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 23, type: "Prowler", color: "Black", row: 7, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 24, type: "DeadLauncher", color: "Black", row: 7, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 24, type: "BoulderThrower", color: "Black", row: 7, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 25, type: "NecroPawn", color: "Black", row: 6, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 25, type: "Pawn", color: "Black", row: 6, col: 0, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 26, type: "NecroPawn", color: "Black", row: 6, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 26, type: "YoungWiz", color: "Black", row: 6, col: 1, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 27, type: "NecroPawn", color: "Black", row: 6, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 27, type: "HellPawn", color: "Black", row: 6, col: 2, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
   { id: 28, type: "NecroPawn", color: "Black", row: 6, col: 3, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
@@ -146,7 +150,12 @@ export const [pieces, setPieces] = createSignal([
   { id: 31, type: "NecroPawn", color: "Black", row: 6, col: 6, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
-  { id: 32, type: "NecroPawn", color: "Black", row: 6, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
+  { id: 32, type: "PawnHopper", color: "Black", row: 6, col: 7, pawnLoaded: false, stunned: false, raisesLeft: 0, pieceLoaded: null, isStone: false,
     gainedAbilities: { knight: false, rook: false, queen: false, pawn: false },
   },
 ]);
+
+// Function to switch the turn
+export function switchTurn() {
+  setCurrentTurn(currentTurn() === "White" ? "Black" : "White");
+}


### PR DESCRIPTION
This pull request introduces several updates to the chess game's frontend logic, focusing on turn-based mechanics, improved handling of special piece interactions, and board state management. The most significant changes enforce turn-based rules, refine special piece behavior, and ensure proper state updates during gameplay.

### Turn-based Mechanics:
* Added turn validation (`currentTurn`) to ensure that players can only move their pieces during their turn across various handlers, including `handleSquareClick`, `handleDeadLauncherClick`, and `handleSacrificeClick`. [[1]](diffhunk://#diff-d79f8a98779a0792fe7881e2b042056773b83c64199fc086b48f4434976a6682L62-R83) [[2]](diffhunk://#diff-fdecd5f6dc9af99ca1009757f3596b17d985f38d5c9e6962ce64b73d16a87b46L29-R28) [[3]](diffhunk://#diff-0866df228cd061fe3f9d9bf3ab2b0154ee5e90ff328bb29d2a80a112769bc44cR16-R29)

### Special Piece Behavior:
* Updated `handleCapture` to account for the self-removal of the `QueenOfDestruction` upon capture.
* Refined resurrection logic to handle turn switching and prevent actions during an opponent's turn. [[1]](diffhunk://#diff-b6e15d0417952b08fcd1bd13266cf3003d41c531a2eeb8f92344e8aaa139ba16R80-R82) [[2]](diffhunk://#diff-b6e15d0417952b08fcd1bd13266cf3003d41c531a2eeb8f92344e8aaa139ba16R96-R102)
* Enhanced `handleDeadLauncherClick` to include additional valid pawn types for loading and enforce turn validation.

### Board State Management:
* Improved `clearBoardState` by resetting additional game states, including `setIsInBoulderMode` and `setIsInLoadingMode`.
* Ensured consistent board redraws and state clearing when invalid actions are attempted, such as out-of-turn sacrifices.

These changes enhance gameplay integrity by enforcing turn-based rules, refining special piece interactions, and ensuring the board state remains consistent.